### PR TITLE
fix(ci): No longer depend on secret for CI checkout

### DIFF
--- a/.github/workflows/action-constants.yaml
+++ b/.github/workflows/action-constants.yaml
@@ -50,7 +50,6 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     repository: ${{ github.repository }}
-                    token: ${{ secrets.RDKCM_BARTON }}
                     fetch-depth: 0
                     fetch-tags: true
             -

--- a/.github/workflows/check-copyright-headers.yaml
+++ b/.github/workflows/check-copyright-headers.yaml
@@ -42,7 +42,6 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     repository: ${{ github.repository }}
-                    token: ${{ secrets.RDKCM_BARTON }}
 
             -
                 name: Get list of added and modified files

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -46,7 +46,6 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     repository: ${{ github.repository }}
-                    token: ${{ secrets.RDKCM_BARTON }}
             -
                 name: Lint PR title and Report Errors
                 env:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -51,7 +51,6 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     repository: ${{ github.repository }}
-                    token: ${{ secrets.RDKCM_BARTON }}
                     fetch-depth: 0
                     fetch-tags: true
             -


### PR DESCRIPTION
We're public now - we don't need it.