### PR TITLE
build!: Refactor library name

### DIFF
--- a/api/c/CMakeLists.txt
+++ b/api/c/CMakeLists.txt
@@ -27,16 +27,16 @@ project(brtn-ds-private)
 
 file(GLOB_RECURSE BRTN_DS_PRIVATE_API_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/private/*.c)
 
-add_library(brtnDeviceServicePrivateAPI STATIC ${BRTN_DS_PRIVATE_API_SOURCES})
+add_library(bDeviceServicePrivateAPI STATIC ${BRTN_DS_PRIVATE_API_SOURCES})
 
-target_link_libraries(brtnDeviceServicePrivateAPI
-        brtnDeviceServiceConfig
+target_link_libraries(bDeviceServicePrivateAPI
+        bDeviceServiceConfig
         xhJsonHelper
         xhDeviceDescriptors
         xhTypes
 )
 
-target_include_directories(brtnDeviceServicePrivateAPI
+target_include_directories(bDeviceServicePrivateAPI
         PRIVATE ${CROSS_OUTPUT}/include/libxml2
         PUBLIC public/private
 )

--- a/config/cmake/modules/BDSAddGLibTest.cmake
+++ b/config/cmake/modules/BDSAddGLibTest.cmake
@@ -31,7 +31,7 @@ function(bds_add_glib_test)
         cmake_parse_arguments(BDS_ADD_GLIB_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
         add_executable(${BDS_ADD_GLIB_TEST_NAME} ${BDS_ADD_GLIB_TEST_SOURCES})
-        target_link_libraries(${BDS_ADD_GLIB_TEST_NAME} PRIVATE brtnDeviceServiceStatic ${BDS_ADD_GLIB_TEST_LIBRARIES})
+        target_link_libraries(${BDS_ADD_GLIB_TEST_NAME} PRIVATE bDeviceServiceStatic ${BDS_ADD_GLIB_TEST_LIBRARIES})
         target_compile_definitions(${BDS_ADD_GLIB_TEST_NAME} PRIVATE G_LOG_DOMAIN="${BDS_ADD_GLIB_TEST_GLOG_DOMAIN}")
         target_include_directories(${BDS_ADD_GLIB_TEST_NAME} PRIVATE ${BDS_ADD_GLIB_TEST_INCLUDE_DIRECTORIES})
 

--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -27,7 +27,7 @@
 # Licensed under the BSD-3 License
 
 # Define an interface library, which will not contain source code but instead provide compile definitions
-add_library(brtnDeviceServiceConfig INTERFACE)
+add_library(bDeviceServiceConfig INTERFACE)
 
 macro(bds_option)
     # Declare an (ON/OFF) Barton cmake config with `NAME`
@@ -52,7 +52,7 @@ macro(bds_option)
 
     if (${BDS_OPTION_NAME})
         message(STATUS "${BDS_OPTION_NAME}=ON --> ${BDS_OPTION_DEFINITION}=1")
-        target_compile_definitions(brtnDeviceServiceConfig INTERFACE "${BDS_OPTION_DEFINITION}=1")
+        target_compile_definitions(bDeviceServiceConfig INTERFACE "${BDS_OPTION_DEFINITION}=1")
     else()
         message(STATUS "${BDS_OPTION_NAME}=OFF --> ${BDS_OPTION_DEFINITION} not defined")
     endif()
@@ -82,7 +82,7 @@ macro(bds_string_option)
         # unaffected by this call.
         string(JOIN "\;" JOINED_OPTION ${${BDS_OPTION_NAME}})
         message(STATUS "${BDS_OPTION_NAME}=${${BDS_OPTION_NAME}} --> ${BDS_OPTION_DEFINITION}=\"${JOINED_OPTION}\"")
-        target_compile_definitions(brtnDeviceServiceConfig INTERFACE "${BDS_OPTION_DEFINITION}=\"${JOINED_OPTION}\"")
+        target_compile_definitions(bDeviceServiceConfig INTERFACE "${BDS_OPTION_DEFINITION}=\"${JOINED_OPTION}\"")
     else()
         message(STATUS "${BDS_OPTION_NAME} unset --> ${BDS_OPTION_DEFINITION} not defined")
     endif()
@@ -108,7 +108,7 @@ macro(bds_int_option)
     if (${BDS_OPTION_NAME})
         if ("${${BDS_OPTION_NAME}}" MATCHES "^[0-9]+$")
             message(STATUS "${BDS_OPTION_NAME}=${${BDS_OPTION_NAME}} --> ${BDS_OPTION_DEFINITION}=${${BDS_OPTION_NAME}}")
-            target_compile_definitions(brtnDeviceServiceConfig INTERFACE "${BDS_OPTION_DEFINITION}=${${BDS_OPTION_NAME}}")
+            target_compile_definitions(bDeviceServiceConfig INTERFACE "${BDS_OPTION_DEFINITION}=${${BDS_OPTION_NAME}}")
         else()
             message(FATAL_ERROR "${BDS_OPTION_NAME}=${${BDS_OPTION_NAME}} - invalid value, must be integer")
         endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -136,7 +136,7 @@ link_directories(${CURL_LIBRARY_DIRS})
 list(APPEND XTRA_INCLUDES ${CURL_INCLUDE_DIRS})
 
 # add library dependencies for this binary
-set(btnDSLinkLibraries brtnDeviceServiceConfig xhLog xhTypes xhTime xhUtil
+set(btnDSLinkLibraries bDeviceServiceConfig xhLog xhTypes xhTime xhUtil
         xhConcurrent xhConfig xhUrlHelper xhXmlHelper xhJsonHelper
         xhDeviceHelper xhDeviceDescriptors xhXmlHelper
         xhCrypto ${XTRA_LIBS} cjson uuid curl xml2 z m)
@@ -148,9 +148,9 @@ endif()
 #FIXME: Reduce copy-paste.
 # Object library type compiles once, then can re-use those object files for
 # statice/shared libraries.
-add_library(brtnDeviceServiceObject OBJECT ${SOURCES} ${BRTN_DS_API_SOURCES})
-target_link_libraries(brtnDeviceServiceObject ${btnDSLinkLibraries})
-target_include_directories(brtnDeviceServiceObject PRIVATE
+add_library(bDeviceServiceObject OBJECT ${SOURCES} ${BRTN_DS_API_SOURCES})
+target_link_libraries(bDeviceServiceObject ${btnDSLinkLibraries})
+target_include_directories(bDeviceServiceObject PRIVATE
                             ${CMAKE_CURRENT_SOURCE_DIR}/src
                             ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers
                             ${XTRA_INCLUDES}
@@ -161,9 +161,9 @@ target_include_directories(brtnDeviceServiceObject PRIVATE
                             ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/public
                             )
 
-add_library(brtnDeviceServiceStatic STATIC $<TARGET_OBJECTS:brtnDeviceServiceObject>)
-target_link_libraries(brtnDeviceServiceStatic ${btnDSLinkLibraries})
-target_include_directories(brtnDeviceServiceStatic PRIVATE
+add_library(bDeviceServiceStatic STATIC $<TARGET_OBJECTS:bDeviceServiceObject>)
+target_link_libraries(bDeviceServiceStatic ${btnDSLinkLibraries})
+target_include_directories(bDeviceServiceStatic PRIVATE
                             ${CMAKE_CURRENT_SOURCE_DIR}/src
                             ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers
                             ${XTRA_INCLUDES}
@@ -172,11 +172,10 @@ target_include_directories(brtnDeviceServiceStatic PRIVATE
                             PUBLIC
                             ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/public
                             )
-install(TARGETS brtnDeviceServiceStatic DESTINATION lib)
 
-add_library(brtnDeviceServiceShared SHARED $<TARGET_OBJECTS:brtnDeviceServiceObject>)
-target_link_libraries(brtnDeviceServiceShared ${btnDSLinkLibraries})
-target_include_directories(brtnDeviceServiceShared PRIVATE
+add_library(bDeviceService SHARED $<TARGET_OBJECTS:bDeviceServiceObject>)
+target_link_libraries(bDeviceService ${btnDSLinkLibraries})
+target_include_directories(bDeviceService PRIVATE
                             ${CMAKE_CURRENT_SOURCE_DIR}/src
                             ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers
                             ${XTRA_INCLUDES}
@@ -185,11 +184,11 @@ target_include_directories(brtnDeviceServiceShared PRIVATE
                             PUBLIC
                             ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/public
                             )
-install(TARGETS brtnDeviceServiceShared DESTINATION lib)
+install(TARGETS bDeviceService DESTINATION lib)
 
 # If specified, generate GIR and typelib. Clients need to ensure that the GIR and/or typelib
-# file is installed, as well is libbrtnDeviceServiceShared.so. Additionally,
-# if libbrtnDeviceServiceShared.so is compiled with sanitizer, clients need to set
+# file is installed, as well is libbDeviceService.so. Additionally,
+# if libbDeviceService.so is compiled with sanitizer, clients need to set
 # LD_PRELOAD ex:
 # LD_PRELOAD=$(gcc -print-file-name=libasan.so) python3 my_app.py
 # LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) python3 my_app.py
@@ -214,7 +213,7 @@ if (BDS_GEN_GIR)
     # The list of --libraries should be only the minimal amount necessary
     # to resolve at run time (and the loader should be able to find everything
     # else through RUNPATH in a client program). However, the scanner needs
-    # paths to dependent libraries even if RUNPATH is set in libbrtnDeviceServiceShared.so.
+    # paths to dependent libraries even if RUNPATH is set in libbDeviceService.so.
     # I don't know why.
 
     set(SCANNER_ARGS
@@ -226,10 +225,10 @@ if (BDS_GEN_GIR)
     --output=${GIR_OUTPUT}
     --include=GObject-2.0
     --include=Gio-2.0
-    --library=brtnDeviceServiceShared
+    --library=bDeviceService
     --library=stdc++
     --library-path=${CMAKE_PREFIX_PATH}/lib
-    -I$<JOIN:$<TARGET_PROPERTY:brtnDeviceServiceShared,INCLUDE_DIRECTORIES>, -I>)
+    -I$<JOIN:$<TARGET_PROPERTY:bDeviceService,INCLUDE_DIRECTORIES>, -I>)
 
     file(GLOB API_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/public/*.h
                            ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/public/events/*.h
@@ -253,7 +252,7 @@ if (BDS_GEN_GIR)
     file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/run_g-ir INPUT ${CMAKE_CURRENT_BINARY_DIR}/run_g-ir.in)
 
     add_custom_command(
-        TARGET brtnDeviceServiceShared POST_BUILD
+        TARGET bDeviceService POST_BUILD
         COMMAND env LD_LIBRARY_PATH=/usr/local/openssl/lib /bin/sh ${CMAKE_CURRENT_BINARY_DIR}/run_g-ir
         COMMENT "Invoking gobject introspection"
     )
@@ -283,7 +282,7 @@ bds_add_cmocka_test(
     NAME testSubsystemManager
     TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test/src/subsystems/subsystemManagerTest.c
     WRAPPED_FUNCTIONS deviceServiceGetSystemProperty deviceServiceSetSystemProperty
-    LINK_LIBRARIES brtnDeviceServiceStatic
+    LINK_LIBRARIES bDeviceServiceStatic
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src ${PRIVATE_API_INCLUDES}
 )
 
@@ -294,7 +293,7 @@ if (BDS_ZIGBEE)
             NAME testZigbeeSubsystem
             TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test/src/subsystems/zigbee/zigbeeSubsystemTest.c
             WRAPPED_FUNCTIONS deviceServiceGetDevicesBySubsystem deviceServiceGetDeviceDescriptorForDevice deviceServiceConfigurationGetFirmwareFileDir
-            LINK_LIBRARIES brtnDeviceServiceStatic
+            LINK_LIBRARIES bDeviceServiceStatic
             INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src ${PRIVATE_API_INCLUDES}
     )
 
@@ -304,7 +303,7 @@ if (BDS_ZIGBEE)
             WRAPPED_FUNCTIONS
                 jsonDatabaseRestore
                 subsystemManagerRestoreConfig
-            LINK_LIBRARIES brtnDeviceServiceStatic
+            LINK_LIBRARIES bDeviceServiceStatic
             INCLUDES ${PRIVATE_API_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
 
@@ -312,7 +311,7 @@ if (BDS_ZIGBEE)
             NAME testZigbeeDriverCommon
             TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test/deviceDrivers/zigbeeDriverCommonTest.c
             WRAPPED_FUNCTIONS deviceServiceGetDevicesBySubsystem
-            LINK_LIBRARIES brtnDeviceServiceStatic
+            LINK_LIBRARIES bDeviceServiceStatic
             INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src ${PRIVATE_API_INCLUDES}
     )
 
@@ -330,7 +329,7 @@ if (BDS_ZIGBEE)
                 storageRestoreNamespace
                 simpleProtectConfigData
                 simpleUnprotectConfigData
-            LINK_LIBRARIES brtnDeviceServiceStatic xhDeviceHelper
+            LINK_LIBRARIES bDeviceServiceStatic xhDeviceHelper
             INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src ${PRIVATE_API_INCLUDES}
     )
 
@@ -343,7 +342,7 @@ if (BDS_ZIGBEE)
                               deviceServiceSetSystemProperty digestFile
                               deviceServiceGetSystemProperty urlHelperDownloadFile
 
-            LINK_LIBRARIES brtnDeviceServiceStatic xhDeviceDescriptors
+            LINK_LIBRARIES bDeviceServiceStatic xhDeviceDescriptors
             INCLUDES ${PRIVATE_API_INCLUDES}
     )
 
@@ -377,7 +376,7 @@ bds_add_cmocka_test(
 if (BDS_MATTER)
     bds_add_cpp_test(NAME testMatterConfigureSubscriptionSpecs
         # TODO: We shouldn't have to explicitly specify the OpenSSL libraries here. Figure this out later.
-        LIBS ${OPENSSL_LINK_LIBRARIES} brtnDeviceServiceStatic
+        LIBS ${OPENSSL_LINK_LIBRARIES} bDeviceServiceStatic
         INCLUDES ${OPENSSL_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers ${CMAKE_BINARY_DIR}/matter-install/include/matter ${PRIVATE_API_INCLUDES} ${XTRA_INCLUDES}
         SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers/matter/test/MatterConfigureSubscriptionSpecsTest.cpp
     )
@@ -386,7 +385,7 @@ if (BDS_MATTER)
         # TODO: For some reason, this target requires these libraries to be linked in a different order from the others.
         # Changing the link order within the bds_add_cpp_test function itself just caused the other targets to fail
         # to link. I don't know why, but for now, we're just explicitly specifying the link order here for this one.
-        LIBS brtnDeviceServiceStatic gtest gmock gmock_main
+        LIBS bDeviceServiceStatic gtest gmock gmock_main
         INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers ${CMAKE_BINARY_DIR}/matter-install/include/matter ${PRIVATE_API_INCLUDES} ${XTRA_INCLUDES}
         SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers/matter/test/MatterSubscribeInteractionTest.cpp
     )
@@ -621,7 +620,7 @@ bds_add_cmocka_test(
         zhalTest
         zigbeeSubsystemPerformEnergyScan
         deviceServiceRestoreConfig
-    LINK_LIBRARIES brtnDeviceServiceStatic
+    LINK_LIBRARIES bDeviceServiceStatic
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src ${PRIVATE_API_INCLUDES}
 )
 if(TARGET device-service-client-test)
@@ -634,7 +633,7 @@ bds_add_cmocka_test(
     WRAPPED_FUNCTIONS
         deviceServiceGetSystemProperty
         deviceServiceSetSystemProperty
-    LINK_LIBRARIES brtnDeviceServiceStatic
+    LINK_LIBRARIES bDeviceServiceStatic
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 if(TARGET device-service-property-provider-test)
@@ -645,7 +644,7 @@ bds_add_cmocka_test(
     NAME deviceServiceConfigurationTest
     TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test/src/deviceServiceConfigurationTest.c
     WRAPPED_FUNCTIONS
-    LINK_LIBRARIES brtnDeviceServiceStatic
+    LINK_LIBRARIES bDeviceServiceStatic
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 

--- a/docker/setupDockerEnv.sh
+++ b/docker/setupDockerEnv.sh
@@ -107,7 +107,7 @@ echo "LSAN_OPTIONS=suppressions=$BARTON_TOP/testing/lsan.supp" >> $OUTFILE
 echo "BARTON_PYTHONPATH=/usr/local/lib/python3.x/dist-packages:/usr/lib/python3/dist-packages:$BARTON_TOP" >> $OUTFILE
 # path to the matter sample apps
 echo "MATTER_SAMPLE_APPS_PATH=$BARTON_TOP/build/matter-install/bin" >> $OUTFILE
-# path to libbrtnDeviceServiceShared.so
+# path to libbDeviceService.so
 echo "LIB_BARTON_SHARED_PATH=/usr/local/lib" >> $OUTFILE
 ##############################################################################
 

--- a/reference/CMakeLists.txt
+++ b/reference/CMakeLists.txt
@@ -33,6 +33,6 @@ add_executable(brtn-ds-reference ${BRTN_DS_REFERENCE_SOURCES})
 
 # add library dependencies for this binary
 target_link_options(brtn-ds-reference PRIVATE -L ${CMAKE_BINARY_DIR}/matter-install/lib)
-target_link_libraries(brtn-ds-reference brtnDeviceServiceShared linenoise)
+target_link_libraries(brtn-ds-reference bDeviceService linenoise)
 
 bds_configure_glib()

--- a/testing/lsan.supp
+++ b/testing/lsan.supp
@@ -25,7 +25,7 @@
 # Created by Kevin Funderburg on 12/16/2024
 #
 
-# In order for pytest to successfully discover tests with libbrtnDeviceServiceShared.so
+# In order for pytest to successfully discover tests with libbDeviceService.so
 # compiled with address santizer, the libasan.so must be pre-loaded before invoking
 # `pytest --collect-only`. However, preloading libasan.so enables AddressSanitizer for the
 # entire process, not just for the specific library compiled with AddressSanitizer.


### PR DESCRIPTION
This commit refactors the library targets of barton to bDeviceService (and bDeviceServiceStatic). Additionally, we don't attempt to install bDeviceServiceStatic as it doesn't make sense to install both the shared object and the static library. Clients relying on the static library should reference the cmake target directly or install it out of band.