### PR TITLE
refactor(core): Use GLib containers in subsystemManager

### DIFF
--- a/core/src/deviceService.c
+++ b/core/src/deviceService.c
@@ -4323,16 +4323,16 @@ DeviceServiceStatus *deviceServiceGetStatus(void)
 
     result->subsystemsJsonStatus = hashMapCreate();
 
-    scoped_icLinkedListGeneric *subsystems = subsystemManagerGetRegisteredSubsystems();
-    sbIcLinkedListIterator *subsystemsIt = linkedListIteratorCreate(subsystems);
-    while (linkedListIteratorHasNext(subsystemsIt))
+    GList *subsystems = subsystemManagerGetRegisteredSubsystems();
+    for (GList *subsystemsIt = subsystems; subsystemsIt != NULL; subsystemsIt = subsystemsIt->next)
     {
-        char *subsystemName = linkedListIteratorGetNext(subsystemsIt);
+        char *subsystemName = (char *) subsystemsIt->data;
         hashMapPut(result->subsystemsJsonStatus,
                    strdup(subsystemName),
                    strlen(subsystemName),
                    subsystemManagerGetSubsystemStatusJson(subsystemName));
     }
+    g_list_free_full(subsystems, g_free);
 
     return result;
 }

--- a/core/src/subsystemManager.h
+++ b/core/src/subsystemManager.h
@@ -195,7 +195,7 @@ void subsystemManagerRegister(Subsystem *subsystem);
 /**
  * Get the names of the registered subsystems.  Caller destroys.
  */
-icLinkedList *subsystemManagerGetRegisteredSubsystems(void);
+GList *subsystemManagerGetRegisteredSubsystems(void);
 
 /**
  * Retrieve the JSON representation of the named subsystems's status


### PR DESCRIPTION
This change replaces the use of `icLinkedList` and `icHashMap` with `GList` and `GHashTable`.

Refs: BARTON-245