### PR TITLE
build: ensure image is built by default

### DIFF
--- a/.github/workflows/action-constants.yaml
+++ b/.github/workflows/action-constants.yaml
@@ -34,6 +34,10 @@ name: Get Action Constants
 on:
   workflow_call:
     outputs:
+        image_repo:
+            description: 'The Docker image repo'
+            value: ${{ jobs.generate-constants.outputs.image_repo_output }}
+
         image_tag:
             description: 'The Docker image tag'
             value: ${{ jobs.generate-constants.outputs.image_tag_output }}
@@ -42,6 +46,7 @@ jobs:
     generate-constants:
         runs-on: ubuntu-latest
         outputs:
+            image_repo_output: ${{ steps.set-image-repo-output.outputs.image_repo }}
             image_tag_output: ${{ steps.set-image-tag-output.outputs.image_tag }}
 
         steps:
@@ -52,6 +57,12 @@ jobs:
                     repository: ${{ github.repository }}
                     fetch-depth: 0
                     fetch-tags: true
+            -
+                id: set-image-repo-output
+                run: |
+                    image_repo=$(grep -m 1 "^IMAGE_REPO=" docker/setupDockerEnv.sh | sed 's/^IMAGE_REPO="\(.*\)"/\1/')
+                    echo "image_repo=$image_repo"
+                    echo "image_repo=$image_repo" >> $GITHUB_OUTPUT
             -
                 id: set-image-tag-output
                 run: |

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -61,9 +61,14 @@ jobs:
                     username: ${{ github.actor }}
                     password: ${{ secrets.GITHUB_TOKEN }}
             -
-                name: Pull barton_builder Docker image
+                name: Try to pull barton_builder Docker image
+                continue-on-error: true
                 run: |
-                     docker pull ghcr.io/rdkcentral/barton_builder:${{ needs.get-action-constants.outputs.image_tag }}
+                    if docker pull ${{ needs.get-action-constants.outputs.image_repo }}:${{ needs.get-action-constants.outputs.image_tag }}; then
+                        echo "Image pulled successfully"
+                    else
+                        echo "Could not pull image, will build locally via dockerw"
+                    fi
             -
                 name: Build BartonCore
                 run: |

--- a/docker/Dockerfile.devcontainer
+++ b/docker/Dockerfile.devcontainer
@@ -30,9 +30,10 @@
 # around the limitation within VSC that the remote user must be baked into the image
 # before run time, unlike the CLI environment.
 
+ARG IMAGE_REPO=""
 ARG IMAGE_TAG=""
 
-FROM ghcr.io/rdkcentral/barton_builder:$IMAGE_TAG
+FROM $IMAGE_REPO:$IMAGE_TAG
 
 ARG BUILDER_USER=""
 ARG BUILDER_GID=""

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -36,4 +36,4 @@ fi
 # `IMAGE_TAG` within `docker/.env`.
 source $docker_env_path
 
-docker build -t ghcr.io/rdkcentral/barton_builder:$IMAGE_TAG ${script_dir}
+docker build -t $IMAGE_REPO:$IMAGE_TAG ${script_dir}

--- a/docker/compose.devcontainer.yaml
+++ b/docker/compose.devcontainer.yaml
@@ -51,6 +51,7 @@ services:
                 - BUILDER_USER=$BUILDER_USER
                 - BUILDER_GID=$BUILDER_GID
                 - BUILDER_UID=$BUILDER_UID
+                - IMAGE_REPO=$IMAGE_REPO
                 - IMAGE_TAG=$IMAGE_TAG
 
 networks:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -35,7 +35,7 @@ services:
     # The devcontainer and dockerw environments will handle this for you, but if you want to run your own
     # `docker compose` commands, you must run `docker/setupDockerEnv.sh` first.
     barton:
-        image: ghcr.io/rdkcentral/barton_builder:$IMAGE_TAG
+        image: $IMAGE_REPO:$IMAGE_TAG
         build:
             context: .
             dockerfile: Dockerfile

--- a/dockerw
+++ b/dockerw
@@ -52,7 +52,7 @@ shift "$(($OPTIND - 1))"
 
 DIR=$(pwd)
 
-# generate the `docker/.env` file and ensure the network is created
+# generate the `docker/.env` file and ensure the network/image is created
 $DIR/docker/setupDockerEnv.sh
 
 DOCKER_ENV_PATH="$DIR/docker/.env"
@@ -60,17 +60,9 @@ DOCKER_ENV_PATH="$DIR/docker/.env"
 # to build/use an image with a custom tag, the tag must be stored in the
 # `docker/.env` file as `IMAGE_TAG=some-tag`
 IMAGE_TAG=$(grep "IMAGE_TAG" "$DOCKER_ENV_PATH" | sed 's/IMAGE_TAG=//')
+IMAGE_REPO=$(grep "IMAGE_REPO" "$DOCKER_ENV_PATH" | sed 's/IMAGE_REPO=//')
 
-IMAGE="ghcr.io/rdkcentral/barton_builder:${IMAGE_TAG}"
-
-if docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "^${IMAGE}$"; then
-    echo "Using existing ${IMAGE}"
-else
-    echo "Image ${IMAGE} not found, building..."
-    pushd docker
-    ./build.sh
-    popd
-fi
+IMAGE="$IMAGE_REPO:$IMAGE_TAG"
 
 EXTRA_VOLUMES="${DEV_VOL}"
 


### PR DESCRIPTION
We found after the repository went public that docker images are not
able to hosted publicly within the organization. This caused build
breaks since outside users were not able to pull the image and also
prevents CI from running in forks.
    
To restore functionality:
    
- add logic to ensure the image is built if it cannot be found locally
- in CI, add logic to see if the image cannot be pulled, indicating a
   fork, and if so, build the image accordingly
    
Additionally, the image repository name is duplicated in many places. To
reduce this duplication, have one source of truth for this value within
`docker/setupDockerEnv` to allow for sourcing by the various Docker
processes.
    
Refs: BARTON-250