### PR TITLE
build: Add missing provider implementations

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -210,7 +210,8 @@ set(MATTER_DELEGATE_DEFAULT_DIR "${MATTER_PROVIDER_DELEGATE_PARENT_DIR}/delegate
 bds_string_option(NAME BDS_MATTER_PROVIDER_IMPLEMENTATIONS
                   DEFINITION BARTON_CONFIG_MATTER_PROVIDER_IMPLEMENTATIONS
                   DESCRIPTION "List of paths to source files that implement Matter provider interfaces."
-                  VALUE "${MATTER_PROVIDER_DEFAULT_DIR}/CertifierDACProvider.cpp;")
+                  VALUE "${MATTER_PROVIDER_DEFAULT_DIR}/CertifierDACProvider.cpp;
+                        ${MATTER_PROVIDER_DEFAULT_DIR}/DefaultCommissionableDataProvider.cpp")
 
 bds_string_option(NAME BDS_MATTER_DELEGATE_IMPLEMENTATIONS
                   DEFINITION BARTON_CONFIG_MATTER_DELEGATE_IMPLEMENTATIONS


### PR DESCRIPTION
Stacked PRs:
 * #19
 * #18
 * __->__#17


--- --- ---

### build: Add missing provider implementations


We added DefaultCommissionableDataProvider for both dev and as the
default provider but forgot to add it to the default value of the
BDS_MATTER_PROVIDER_IMPLEMENTATIONS config option. Likely a consequence
of merge conflict handling at the time.
