### PR TITLE
build: improve Docker tag management and container warnings

### DIFF
--- a/docker/setupDockerEnv.sh
+++ b/docker/setupDockerEnv.sh
@@ -57,16 +57,55 @@ OUTFILE=$DIR/.env
 BARTON_TOP=$DIR/..
 IMAGE_REPO="ghcr.io/rdkcentral/barton_builder"
 
-# Find the highest versioned image tag reachable by HEAD that matches 'docker-builder-*'
-IMAGE_TAG=$(git tag -l 'docker-builder-*' --sort=-v:refname --merged | head -n 1 | sed 's/docker-builder-//')
+# Docker image version management
+#
+# This system automatically updates to the latest compatible Docker builder image
+# while handling user customizations in a predictable way:
+# - Always updates when a newer builder version is available to ensure builds
+#   use compatible toolchains and dependencies
+# - Warns when custom tags exist based on outdated builders
+# - Allows restoring custom tags after updates if needed
+#
+# The version tags are tied to git tags (docker-builder-*) to maintain consistency
+# between code and build environment versions.
 
-# Check if there is an image tag already defined in the .env file. If so, this could
-# imply the user has has defined a custom tag to use for the build process.
+# Find the highest versioned image tag reachable by HEAD that matches 'docker-builder-*'
+HIGHEST_BUILDER_TAG=$(git tag -l 'docker-builder-*' --sort=-v:refname --merged | head -n 1 | sed 's/docker-builder-//')
+IMAGE_TAG=$HIGHEST_BUILDER_TAG
+BUILDER_TAG_OUT_OF_DATE=false
+
 if [ -f "$OUTFILE" ]; then
-    if grep -q "IMAGE_TAG" "$OUTFILE"; then
-        IMAGE_TAG=$(grep "IMAGE_TAG" "$OUTFILE" | sed 's/IMAGE_TAG=//')
+
+    CURRENT_BUILDER_TAG=$(grep "CURRENT_BUILDER_TAG=" "$OUTFILE" | sed 's/CURRENT_BUILDER_TAG=//')
+
+    if [ "$HIGHEST_BUILDER_TAG" != "$CURRENT_BUILDER_TAG" ]; then
+        echo "Current docker-builder tag ($CURRENT_BUILDER_TAG) is out of date. The latest tag is $HIGHEST_BUILDER_TAG."
+        echo "The value of IMAGE_TAG in docker/.env will be updated to use latest version"
+        BUILDER_TAG_OUT_OF_DATE=true
     fi
+
+    IMAGE_TAG=$(grep "IMAGE_TAG" "$OUTFILE" | sed 's/IMAGE_TAG=//')
+
+    CUSTOM_TAG=false
+    if [ "$IMAGE_TAG" != "$CURRENT_BUILDER_TAG" ]; then
+        CUSTOM_TAG=true
+    fi
+
+    if [ "$CUSTOM_TAG" = true ] && [ "$BUILDER_TAG_OUT_OF_DATE" = true ]; then
+        echo "WARNING: The custom image tag '$IMAGE_TAG' is based on an older builder image ($CURRENT_BUILDER_TAG)."
+        echo "1. Rebase your docker related changes in '$IMAGE_TAG' to the latest version ($HIGHEST_BUILDER_TAG)"
+        echo "2. Rebuild your custom image"
+        echo "3. Set the value of IMAGE_TAG in docker/.env back to '$IMAGE_TAG'."
+        echo "4. Rebuild your environment - either devcontainer or CLI container."
+    fi
+
+    if [ "$BUILDER_TAG_OUT_OF_DATE" = true ]; then
+        IMAGE_TAG=$HIGHEST_BUILDER_TAG
+    fi
+
 fi
+
+CURRENT_BUILDER_TAG=$HIGHEST_BUILDER_TAG
 
 ##############################################################################
 # Variables needed to facilitate the Docker compose process. See docker/compose.yaml
@@ -80,8 +119,10 @@ echo "BUILDER_GID=$(id -g)" >> $OUTFILE
 # Save off the path to the Barton directory so we can mount it in the same path in the container
 echo "BARTON_TOP=$BARTON_TOP" >> $OUTFILE
 # Save off the image repo/tag into the .env file so it can be used in the compose process
-echo "IMAGE_TAG=$IMAGE_TAG" >> $OUTFILE
 echo "IMAGE_REPO=$IMAGE_REPO" >> $OUTFILE
+echo "IMAGE_TAG=$IMAGE_TAG" >> $OUTFILE
+# Save off the current builder tag to keep track of the latest version
+echo "CURRENT_BUILDER_TAG=$CURRENT_BUILDER_TAG" >> $OUTFILE
 ##############################################################################
 
 ##############################################################################

--- a/docker/setupDockerEnv.sh
+++ b/docker/setupDockerEnv.sh
@@ -93,10 +93,10 @@ if [ -f "$OUTFILE" ]; then
 
     if [ "$CUSTOM_TAG" = true ] && [ "$BUILDER_TAG_OUT_OF_DATE" = true ]; then
         echo "WARNING: The custom image tag '$IMAGE_TAG' is based on an older builder image ($CURRENT_BUILDER_TAG)."
-        echo "1. Rebase your docker related changes in '$IMAGE_TAG' to the latest version ($HIGHEST_BUILDER_TAG)"
-        echo "2. Rebuild your custom image"
-        echo "3. Set the value of IMAGE_TAG in docker/.env back to '$IMAGE_TAG'."
-        echo "4. Rebuild your environment - either devcontainer or CLI container."
+        echo "To continue using your custom tag, you should:"
+        echo "1. Rebuild your custom image"
+        echo "2. Set the value of IMAGE_TAG in docker/.env back to '$IMAGE_TAG'"
+        echo "3. Rebuild your environment - either devcontainer or CLI container"
     fi
 
     if [ "$BUILDER_TAG_OUT_OF_DATE" = true ]; then

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -29,7 +29,7 @@ MY_DIR=$(realpath $(dirname $0))
 TOP_DIR=${MY_DIR}/..
 HOOKS_DIR=${TOP_DIR}/.git/hooks
 
-HOOKS_SUPPORTED=(pre-commit)
+HOOKS_SUPPORTED=(pre-commit post-checkout)
 
 # Copy various hooks, namespaced
 cp ${MY_DIR}/clang-format-hooks/apply-format ${HOOKS_DIR}/

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Skip check for non-interactive operations
+[ -t 1 ] || exit 0
+
+# Check if we're inside a container
+if [ -f "/.dockerenv" ] && [ -n "$CURRENT_BUILDER_TAG" ]; then
+    # Get latest tag from git
+    LATEST_BUILDER_TAG=$(git tag -l 'docker-builder-*' --sort=-v:refname --merged | head -n 1 | sed 's/docker-builder-//')
+
+    if [ -n "$LATEST_BUILDER_TAG" ] && [ "$CURRENT_BUILDER_TAG" != "$LATEST_BUILDER_TAG" ]; then
+        echo ""
+        echo "********************************************************************"
+        echo "WARNING: Your container is based on the docker-builder version $CURRENT_BUILDER_TAG,"
+        echo "         but the latest version for this code is $LATEST_BUILDER_TAG"
+        echo ""
+        echo "         If on CLI:"
+        echo "             You should exit and rebuild your container with:"
+        echo "             $ exit"
+        echo "             $ ./dockerw"
+        echo "         If in a devcontainer:"
+        echo "             You should rebuild your devcontainer by:"
+        echo "             1. Opening the command palette (Ctrl+Shift+P)"
+        echo "             2. Search & select 'Rebuild Container'"
+        echo "********************************************************************"
+        echo ""
+    fi
+fi

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,11 +1,38 @@
 #!/bin/bash
 
+# ------------------------------ tabstop = 4 ----------------------------------
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# ------------------------------ tabstop = 4 ----------------------------------
+
+#
+# Created by Kevin Funderburg on 5/27/2025.
+#
+
 # Skip check for non-interactive operations
 [ -t 1 ] || exit 0
 
 # Check if we're inside a container
 if [ -f "/.dockerenv" ] && [ -n "$CURRENT_BUILDER_TAG" ]; then
-    # Get latest tag from git
+    # Find the highest versioned image tag reachable by HEAD that matches 'docker-builder-*'
     LATEST_BUILDER_TAG=$(git tag -l 'docker-builder-*' --sort=-v:refname --merged | head -n 1 | sed 's/docker-builder-//')
 
     if [ -n "$LATEST_BUILDER_TAG" ] && [ "$CURRENT_BUILDER_TAG" != "$LATEST_BUILDER_TAG" ]; then
@@ -21,7 +48,7 @@ if [ -f "/.dockerenv" ] && [ -n "$CURRENT_BUILDER_TAG" ]; then
         echo "         If in a devcontainer:"
         echo "             You should rebuild your devcontainer by:"
         echo "             1. Opening the command palette (Ctrl+Shift+P)"
-        echo "             2. Search & select 'Rebuild Container'"
+        echo "             2. Search & select 'Dev Containers: Rebuild Container'"
         echo "********************************************************************"
         echo ""
     fi

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -39,7 +39,7 @@ if [ -f "/.dockerenv" ] && [ -n "$CURRENT_BUILDER_TAG" ]; then
         echo ""
         echo "********************************************************************"
         echo "WARNING: Your container is based on the docker-builder version $CURRENT_BUILDER_TAG,"
-        echo "         but the latest version for this code is $LATEST_BUILDER_TAG"
+        echo "         but the latest version for this lineage is $LATEST_BUILDER_TAG"
         echo ""
         echo "         If on CLI:"
         echo "             You should exit and rebuild your container with:"


### PR DESCRIPTION
Add post-checkout hook to warn users when running in outdated containers after git operations like pull/checkout. This ensures developers are notified when their development environment needs to be rebuilt due to Docker image version requirements changing.

Also enhance Docker tag management to automatically use the highest versioned git tag (docker-builder-*) for image versioning, ensuring builds use compatible toolchains while handling custom tags gracefully. The system warns users when custom tags are based on outdated builders and provides guidance on updating, maintaining consistent environments across the team.

Refs: BARTON-246