### PR TITLE
fix: Don't reference BartonProjectConfig.h

### DIFF
--- a/core/src/subsystems/matter/providers/BartonCommissionableDataProvider.cpp
+++ b/core/src/subsystems/matter/providers/BartonCommissionableDataProvider.cpp
@@ -26,7 +26,6 @@
 //
 
 #include "BartonCommissionableDataProvider.hpp"
-#include "BartonProjectConfig.h"
 #include "crypto/CHIPCryptoPAL.h"
 #include "lib/core/CHIPError.h"
 #include "lib/support/Span.h"


### PR DESCRIPTION
We should not be ever referencing BartonProjectConfig.h or any equivalent header. This header is used by the matter sdk build to configure certain things in the matter sdk and any given client may or may not create one or even by some other name. It should be opaque to BartonCore code.

Luckily the only reference was an unused header include.

Refs: BARTON-252