### PR TITLE
feat(core): Add ZigbeeRemoteCliResponseEvent

### DIFF
--- a/api/c/public/device-service-client.h
+++ b/api/c/public/device-service-client.h
@@ -128,10 +128,12 @@ GQuark b_device_service_client_error_quark(void);
 // signal handler args: BDeviceServiceDeviceDatabaseFailureEvent *event
 #define B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_METADATA_UPDATED               "metadata-updated"
 // signal handler args: BDeviceServiceMetadataUpdatedEvent *event
+#define B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED                                \
+    "zigbee-remote-cli-command-response-received"
+// signal handler args: BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *event
 
 // TODO - implement these
 #define B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_ZIGBEE_SUBSYSTEM_STATUS_CHANGED
-#define B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED
 
 /****************** Signals End **********************************/
 

--- a/api/c/public/events/device-service-zigbee-remote-cli-command-response-received-event.h
+++ b/api/c/public/events/device-service-zigbee-remote-cli-command-response-received-event.h
@@ -1,0 +1,65 @@
+//------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2024 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//------------------------------ tabstop = 4 ----------------------------------
+
+/*
+ * Created by Ganesh Induri on 05/27/2025.
+ */
+
+#pragma once
+
+#include "events/device-service-event.h"
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_TYPE                                        \
+    (b_device_service_zigbee_remote_cli_command_response_received_event_get_type())
+G_DECLARE_FINAL_TYPE(BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent,
+                     b_device_service_zigbee_remote_cli_command_response_received_event,
+                     B_DEVICE_SERVICE,
+                     ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT,
+                     BDeviceServiceEvent)
+
+typedef enum
+{
+    B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID = 1,
+    B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE,
+    N_B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTIES
+} BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEventProperty;
+
+static const char *B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES[] = {
+    NULL,
+    "uuid",
+    "command-response"};
+
+/**
+ * b_device_service_zigbee_remote_cli_command_response_received_event_new
+ *
+ * @brief
+ *
+ * @return BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent*
+ */
+BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *
+b_device_service_zigbee_remote_cli_command_response_received_event_new(void);
+
+G_END_DECLS

--- a/api/c/src/events/device-service-zigbee-remote-cli-command-response-received-event.c
+++ b/api/c/src/events/device-service-zigbee-remote-cli-command-response-received-event.c
@@ -1,0 +1,142 @@
+//------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2024 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//------------------------------ tabstop = 4 ----------------------------------
+
+/*
+ * Created by Ganesh Induri on 05/27/2025.
+ */
+
+#include "events/device-service-zigbee-remote-cli-command-response-received-event.h"
+
+struct _BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent
+{
+    BDeviceServiceEvent parent_instance;
+
+    gchar *uuid;
+    gchar *command_response;
+};
+
+G_DEFINE_TYPE(BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent,
+              b_device_service_zigbee_remote_cli_command_response_received_event,
+              B_DEVICE_SERVICE_EVENT_TYPE)
+
+static GParamSpec *properties[N_B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTIES];
+
+static void b_device_service_zigbee_remote_cli_command_response_received_event_init(
+    BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *self)
+{
+    self->uuid = NULL;
+    self->command_response = NULL;
+}
+
+static void b_device_service_zigbee_remote_cli_command_response_received_event_finalize(GObject *object)
+{
+    BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *self =
+        B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT(object);
+
+    g_free(self->uuid);
+    g_free(self->command_response);
+
+    G_OBJECT_CLASS(b_device_service_zigbee_remote_cli_command_response_received_event_parent_class)->finalize(object);
+}
+
+static void b_device_service_zigbee_remote_cli_command_response_received_event_get_property(GObject *object,
+                                                                                            guint property_id,
+                                                                                            GValue *value,
+                                                                                            GParamSpec *pspec)
+{
+    BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *self =
+        B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT(object);
+
+    switch (property_id)
+    {
+        case B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID:
+            g_value_set_string(value, self->uuid);
+            break;
+        case B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE:
+            g_value_set_string(value, self->command_response);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+            break;
+    }
+}
+
+static void b_device_service_zigbee_remote_cli_command_response_received_event_set_property(GObject *object,
+                                                                                            guint property_id,
+                                                                                            const GValue *value,
+                                                                                            GParamSpec *pspec)
+{
+    BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *self =
+        B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT(object);
+
+    switch (property_id)
+    {
+        case B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID:
+            g_free(self->uuid);
+            self->uuid = g_value_dup_string(value);
+            break;
+        case B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE:
+            g_free(self->command_response);
+            self->command_response = g_value_dup_string(value);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+            break;
+    }
+}
+
+static void b_device_service_zigbee_remote_cli_command_response_received_event_class_init(
+    BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEventClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+    object_class->finalize = b_device_service_zigbee_remote_cli_command_response_received_event_finalize;
+    object_class->get_property = b_device_service_zigbee_remote_cli_command_response_received_event_get_property;
+    object_class->set_property = b_device_service_zigbee_remote_cli_command_response_received_event_set_property;
+
+    properties[B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID] =
+        g_param_spec_string(B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                                [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID],
+                            "UUID",
+                            "The UUID of the device that sent the command response",
+                            NULL,
+                            G_PARAM_READWRITE);
+
+    properties[B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE] =
+        g_param_spec_string(
+            B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE],
+            "Command Response",
+            "The command response received from the Zigbee remote CLI",
+            NULL,
+            G_PARAM_READWRITE);
+
+    g_object_class_install_properties(
+        object_class, N_B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTIES, properties);
+}
+
+BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *
+b_device_service_zigbee_remote_cli_command_response_received_event_new(void)
+{
+    return g_object_new(B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_TYPE, NULL);
+}

--- a/api/c/test/events/device-service-zigbee-remote-cli-response-received-event-test.c
+++ b/api/c/test/events/device-service-zigbee-remote-cli-response-received-event-test.c
@@ -1,0 +1,107 @@
+//------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2024 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//------------------------------ tabstop = 4 ----------------------------------
+
+/*
+ * Created by Ganesh Induri on 05/27/2025.
+ */
+
+#include "events/device-service-zigbee-remote-cli-command-response-received-event.h"
+#include "glibconfig.h"
+#include <glib-object.h>
+
+typedef struct
+{
+    BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *event;
+} BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest;
+
+static void setup(BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest *test, gconstpointer user_data)
+{
+    test->event = b_device_service_zigbee_remote_cli_command_response_received_event_new();
+}
+
+// Teardown function called after each test
+static void teardown(BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest *test, gconstpointer user_data)
+{
+    g_clear_object(&test->event);
+}
+
+static void test_event_creation(BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest *test, gconstpointer user_data)
+{
+    g_assert_nonnull(test->event);
+}
+
+static void test_property_access(BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest *test, gconstpointer user_data)
+{
+    g_object_set(test->event,
+                 B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                     [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID],
+                 "my-uuid",
+                 NULL);
+
+    gchar *uuid_test = NULL;
+    g_object_get(test->event,
+                 B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                     [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID],
+                 &uuid_test,
+                 NULL);
+    g_assert_cmpstr("my-uuid", ==, uuid_test);
+    g_free(uuid_test);
+
+    g_object_set(test->event,
+                 B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                     [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE],
+                 "myCommandResponse",
+                 NULL);
+
+    gchar *command_response_test = NULL;
+    g_object_get(test->event,
+                 B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                     [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE],
+                 &command_response_test,
+                 NULL);
+    g_assert_cmpstr("myCommandResponse", ==, command_response_test);
+    g_free(command_response_test);
+}
+
+int main(int argc, char *argv[])
+{
+    // Initialize GLib testing framework
+    g_test_init(&argc, &argv, NULL);
+
+    // Define the test suite
+    g_test_add("/device-service-zigbee-remote-cli-response-received-event/event-creation",
+               BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest,
+               NULL,
+               setup,
+               test_event_creation,
+               teardown);
+    g_test_add("/device-service-zigbee-remote-cli-response-received-event/property-access",
+               BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest,
+               NULL,
+               setup,
+               test_property_access,
+               teardown);
+
+    // Run the tests
+    return g_test_run();
+}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -599,6 +599,13 @@ bds_add_glib_test(
 )
 
 bds_add_glib_test(
+    NAME device-service-zigbee-remote-cli-response-received-event-test
+    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/test/events/device-service-zigbee-remote-cli-response-received-event-test.c
+    INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/src ${PRIVATE_API_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR}/src
+    GLOG_DOMAIN BDeviceServiceZigbeeRemoteCliResponseReceivedEventTest
+)
+
+bds_add_glib_test(
     NAME device-service-utils-test
     SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/test/device-service-utils-test.c
     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../api/c/src ${PRIVATE_API_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/core/src/event/deviceEventProducer.c
+++ b/core/src/event/deviceEventProducer.c
@@ -61,6 +61,7 @@
 #include "events/device-service-zigbee-channel-changed-event.h"
 #include "events/device-service-zigbee-interference-event.h"
 #include "events/device-service-zigbee-pan-id-attack-changed-event.h"
+#include "events/device-service-zigbee-remote-cli-command-response-received-event.h"
 #include "icLog/logging.h"
 #include <device-driver/device-driver.h>
 #include <device/icDeviceEndpoint.h>
@@ -109,6 +110,7 @@ enum DEVICE_SERVICE_SIGNALS
     SIGNAL_PAN_ID_ATTACK_CHANGED,
     SIGNAL_DEVICE_DATABASE_FAILURE,
     SIGNAL_METADATA_UPDATED,
+    SIGNAL_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED,
 
     SIGNAL_MAX
 };
@@ -385,6 +387,18 @@ void deviceEventProducerClassInit(BDeviceServiceClientClass *deviceServiceClass)
                                                     G_TYPE_NONE,
                                                     1,
                                                     B_DEVICE_SERVICE_METADATA_UPDATED_EVENT_TYPE);
+
+    signals[SIGNAL_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED] =
+        g_signal_new(B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED,
+                     G_TYPE_FROM_CLASS(deviceServiceClass),
+                     G_SIGNAL_RUN_LAST,
+                     0,
+                     NULL,
+                     NULL,
+                     NULL,
+                     G_TYPE_NONE,
+                     1,
+                     B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_TYPE);
 }
 
 void deviceEventProducerStartup(BDeviceServiceClient *_service)
@@ -758,7 +772,22 @@ void sendZigbeePanIdAttackEvent(bool attackDetected)
     g_signal_emit(service, signals[SIGNAL_PAN_ID_ATTACK_CHANGED], 0, event);
 }
 
-void sendZigbeeRemoteCliCommandResponseReceivedEvent(const char *uuid, const char *commandResponse) {}
+void sendZigbeeRemoteCliCommandResponseReceivedEvent(const char *uuid, const char *commandResponse)
+{
+    g_autoptr(BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent) event =
+        b_device_service_zigbee_remote_cli_command_response_received_event_new();
+
+    g_object_set(event,
+                 B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                     [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_UUID],
+                 uuid,
+                 B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                     [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE],
+                 commandResponse,
+                 NULL);
+
+    g_signal_emit(service, signals[SIGNAL_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED], 0, event);
+}
 
 void sendDeviceConfigureStartedEvent(const char *deviceClass, const char *uuid, bool forRecovery)
 {

--- a/reference/src/eventHandler.c
+++ b/reference/src/eventHandler.c
@@ -42,6 +42,7 @@
 #include "events/device-service-endpoint-removed-event.h"
 #include "events/device-service-metadata-updated-event.h"
 #include "events/device-service-resource-updated-event.h"
+#include "events/device-service-zigbee-remote-cli-command-response-received-event.h"
 #include "utils.h"
 #include <stdio.h>
 
@@ -58,6 +59,8 @@ static void metadataUpdated(BDeviceServiceClient *source, BDeviceServiceMetadata
 static void deviceRemovedEventHandler(BDeviceServiceClient *source, BDeviceServiceDeviceRemovedEvent *event);
 static void endpointRemovedEventHandler(BDeviceServiceClient *source, BDeviceServiceEndpointRemovedEvent *event);
 static void resourceUpdatedHandler(BDeviceServiceClient *source, BDeviceServiceResourceUpdatedEvent *event);
+static void zigbeeRemoteCliResponseEventHandler(BDeviceServiceClient *source,
+                                                BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *event);
 
 
 void registerEventHandlers(BDeviceServiceClient *client)
@@ -88,6 +91,10 @@ void registerEventHandlers(BDeviceServiceClient *client)
         client, B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_ENDPOINT_REMOVED, G_CALLBACK(endpointRemovedEventHandler), NULL);
     g_signal_connect(
         client, B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_RESOURCE_UPDATED, G_CALLBACK(resourceUpdatedHandler), NULL);
+    g_signal_connect(client,
+                     B_DEVICE_SERVICE_CLIENT_SIGNAL_NAME_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED,
+                     G_CALLBACK(zigbeeRemoteCliResponseEventHandler),
+                     NULL);
 }
 
 void unregisterEventHandlers(void)
@@ -341,4 +348,18 @@ static void resourceUpdatedHandler(BDeviceServiceClient *source, BDeviceServiceR
     {
         emitOutput("\r\nresourceUpdated: %s\n", resourceDump);
     }
+}
+
+static void zigbeeRemoteCliResponseEventHandler(BDeviceServiceClient *source,
+                                                BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent *event)
+{
+    g_autofree gchar *commandResponse = NULL;
+
+    g_object_get(G_OBJECT(event),
+                 B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROPERTY_NAMES
+                     [B_DEVICE_SERVICE_ZIGBEE_REMOTE_CLI_COMMAND_RESPONSE_RECEIVED_EVENT_PROP_COMMAND_RESPONSE],
+                 &commandResponse,
+                 NULL);
+
+    emitOutput("%s\n", commandResponse);
 }


### PR DESCRIPTION
This commit adds BDeviceServiceZigbeeRemoteCliCommandResponseReceivedEvent. The implementation includes the GObject definition, property accessors, and signal emission logic required to handle Zigbee remote CLI command responses.