### PR TITLE
chore(hooks): Update clang-format-hooks

### DIFF
--- a/hooks/clang-format-hooks/apply-format
+++ b/hooks/clang-format-hooks/apply-format
@@ -302,7 +302,11 @@ else # Diff-only.
         readonly patch_dest=/dev/stdout
     fi
 
-    declare git_args=(git diff -U0 --no-color)
+    # To support git when it is configured to use a non-default prefix, use
+    # --src-prefix and --dst-prefix to set the default prefixes explicitly. We
+    # don't use the newer --default-prefix option because we want to support git
+    # versions older than 2.41.
+    declare git_args=(git diff -U0 --no-color --src-prefix=a/ --dst-prefix=b/)
     [ "$staged" = true ] && git_args+=("--staged")
 
     # $format_diff may contain a command ("python") and the script to excute, so we
@@ -325,8 +329,10 @@ else # Diff-only.
             -p1 \
             -style="$style" \
             -iregex="$exclusions_regex"'.*\.(c|cpp|cxx|cc|h|hpp|m|mm|js|java)' \
-            > "$patch_dest" \
-        || exit 1
+            > "$patch_dest"
+    # Starting with version 18, clang-format-diff exits with status 1 when there
+    # are diffs, but other non-zero statuses indicate errors.
+    [ $? -gt 1 ] && exit $?
 
     if [ "$apply_to_staged" = true ]; then
         if [ ! -s "$patch_dest" ]; then

--- a/hooks/clang-format-hooks/git-pre-commit-format
+++ b/hooks/clang-format-hooks/git-pre-commit-format
@@ -287,6 +287,15 @@ fi
 
 # The code is not formatted correctly.
 
+if hash colordiff 2> /dev/null; then
+    colordiff < "$patch"
+else
+    echo "${b}(Install colordiff to see this diff in color!)${n}"
+    echo
+    cat "$patch"
+fi
+echo
+
 interactive=$(cd "$top_dir" && git config --bool hooks.clangFormatDiffInteractive)
 if [ "$interactive" != false ]; then
     # Interactive is the default, so anything that is not false is converted to
@@ -305,14 +314,6 @@ if [ "$interactive" = false ]; then
     exit 1
 fi
 
-if hash colordiff 2> /dev/null; then
-    colordiff < "$patch"
-else
-    echo "${b}(Install colordiff to see this diff in color!)${n}"
-    echo
-    cat "$patch"
-fi
-
 # We don't want to suggest applying clang-format after merge resolution
 if git rev-parse MERGE_HEAD >/dev/null 2>&1; then
     readonly this_is_a_merge=true
@@ -320,7 +321,6 @@ else
     readonly this_is_a_merge=false
 fi
 
-echo
 echo "${b}The staged content is not formatted correctly.${n}"
 echo "The fix shown above can be applied automatically to the commit."
 echo


### PR DESCRIPTION
Our version of apply-format was old and not compatible with clang-format version 18+. This made committing very difficult if you had the hook installed.