### PR TITLE
fix(matter): Fix possible null dereference

### DIFF
--- a/core/src/subsystems/matter/providers/default/CertifierDACProvider.cpp
+++ b/core/src/subsystems/matter/providers/default/CertifierDACProvider.cpp
@@ -163,7 +163,8 @@ CHIP_ERROR CertifierDACProvider::SignWithDeviceAttestationKey(const ByteSpan & m
 std::string CertifierDACProvider::GetDACFilepath()
 {
     g_autoptr(BDeviceServicePropertyProvider) propertyProvider = deviceServiceConfigurationGetPropertyProvider();
-    g_autofree char *dacFilePath = b_device_service_property_provider_get_property_as_string(propertyProvider, DEVICE_PROP_MATTER_DAC_P12_PATH,  nullptr);
+    g_autofree char *dacFilePath = b_device_service_property_provider_get_property_as_string(
+        propertyProvider, DEVICE_PROP_MATTER_DAC_P12_PATH, "");
 
     return std::string(dacFilePath);
 }
@@ -171,7 +172,8 @@ std::string CertifierDACProvider::GetDACFilepath()
 std::string CertifierDACProvider::GetDACPassword()
 {
     g_autoptr(BDeviceServicePropertyProvider) propertyProvider = deviceServiceConfigurationGetPropertyProvider();
-    g_autofree char *dacPassword = b_device_service_property_provider_get_property_as_string(propertyProvider, DEVICE_PROP_MATTER_DAC_P12_PASSWORD, nullptr);
+    g_autofree char *dacPassword = b_device_service_property_provider_get_property_as_string(
+        propertyProvider, DEVICE_PROP_MATTER_DAC_P12_PASSWORD, "");
 
     return std::string(dacPassword);
 }


### PR DESCRIPTION
If a client compiled with the default CertifierDACProvider but did not properly set the required properties, the class would default passing nullptr to std::string's constructor. This is undefined behavior and would often lead to a null dereference and a crash.

While a client SHOULD set "device.matter.dacP12Path" and "device.matter.dacP12Password" to properly use the CertifierDACProvider, failure to do so should not crash the program.

Refs: BARTON-241