### PR TITLE
feat(matter): Client provided commissioning params

### DIFF
--- a/core/src/subsystems/matter/Matter.cpp
+++ b/core/src/subsystems/matter/Matter.cpp
@@ -1264,12 +1264,21 @@ bool Matter::OpenCommissioningWindow(chip::NodeId nodeId,
     // since we (or the remote device) are already commissioned, we can only support on network commissioning
     setupPayload.rendezvousInformation.SetValue(RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork));
 
-    uint16_t discriminator = Crypto::GetRandU16() % kMaxDiscriminator;
+    uint16_t discriminator = 0;
+    if (commissionableDataProvider->GetSetupDiscriminator(discriminator)!= CHIP_NO_ERROR)
+    {
+        icError("Failed to get setup discriminator from CommissionableDataProvider");
+        return false;
+    }
     setupPayload.discriminator.SetLongValue(discriminator);
 
-    DRBG_get_bytes(reinterpret_cast<uint8_t *>(&setupPayload.setUpPINCode), sizeof(setupPayload.setUpPINCode));
-    // Passcodes shall be restricted to the values 00000001 to 99999998 in decimal, see 5.1.1.6
-    setupPayload.setUpPINCode = (setupPayload.setUpPINCode % kSetupPINCodeMaximumValue) + 1;
+    uint32_t setupPINCode = 0;
+    if (commissionableDataProvider->GetSetupPasscode(setupPINCode) != CHIP_NO_ERROR)
+    {
+        icError("Failed to get setup passcode from CommissionableDataProvider");
+        return false;
+    }
+    setupPayload.setUpPINCode = setupPINCode;
 
     if (timeoutSecs == 0)
     {
@@ -1319,7 +1328,7 @@ bool Matter::OpenCommissioningWindow(chip::NodeId nodeId,
                                        nodeId,
                                        System::Clock::Seconds16(timeoutSecs),
                                        kDefaultPAKEIterationCount,
-                                       discriminator,
+                                       setupPayload.discriminator.GetLongValue(),
                                        MakeOptional<uint32_t>(setupPayload.setUpPINCode),
                                        NullOptional,
                                        setupPayload);

--- a/reference/src/device-service-reference-app.c
+++ b/reference/src/device-service-reference-app.c
@@ -29,6 +29,7 @@
 #include "device-service-client.h"
 #include "device-service-initialize-params-container.h"
 #include "device-service-reference-io.h"
+#include "device-service-properties.h"
 #include "eventHandler.h"
 #include "matterCategory.h"
 #include "threadCategory.h"
@@ -181,6 +182,34 @@ static gchar *getDefaultConfigDirectory(void)
     return confDir;
 }
 
+static void setDefaultParameters(BDeviceServiceInitializeParamsContainer *params)
+{
+    BDeviceServicePropertyProvider *propProvider =
+        b_device_service_initialize_params_container_get_property_provider(params);
+    if (propProvider != NULL)
+    {
+        // set default discriminator if not already set
+        guint16 discriminator = b_device_service_property_provider_get_property_as_uint16(
+            propProvider, B_DEVICE_SERVICE_BARTON_MATTER_SETUP_DISCRIMINATOR, 0);
+        if (discriminator == 0)
+        {
+            // Use the well-known development discriminator 3840
+            b_device_service_property_provider_set_property_uint16(
+                propProvider, B_DEVICE_SERVICE_BARTON_MATTER_SETUP_DISCRIMINATOR, 3840);
+        }
+
+        // set default passcode if not already set
+        guint32 passcode = b_device_service_property_provider_get_property_as_uint32(
+            propProvider, B_DEVICE_SERVICE_BARTON_MATTER_SETUP_PASSCODE, 0);
+        if (passcode == 0)
+        {
+            // Use the well-known development passcode 20202021
+            b_device_service_property_provider_set_property_uint32(
+                propProvider, B_DEVICE_SERVICE_BARTON_MATTER_SETUP_PASSCODE, 20202021);
+        }
+    }
+}
+
 static void configureSubsystems(BDeviceServiceInitializeParamsContainer *params)
 {
     BDeviceServicePropertyProvider *propProvider =
@@ -244,6 +273,7 @@ static BDeviceServiceClient *initializeClient(gchar *confDir)
 
     BDeviceServiceClient *client = b_device_service_client_new(params);
     configureSubsystems(params);
+    setDefaultParameters(params);
     return client;
 }
 


### PR DESCRIPTION
This change unifies the discriminator and passcode used for commissioning between remote requests to open commissioning and internal/client invoked through the Barton API. In both cases the registered CommissionableDataProvider is used to provide these parameters.

This change also has the reference app set the discriminator and passcode to the same values as the ones used commonly in the Matter SDK if they are not already set.

Refs: BARTON-260