### PR TITLE
fix(props): case insensitive bool props

### DIFF
--- a/api/c/src/provider/device-service-property-provider.c
+++ b/api/c/src/provider/device-service-property-provider.c
@@ -197,7 +197,7 @@ gboolean b_device_service_property_provider_get_property_as_bool(BDeviceServiceP
         return default_value;
     }
 
-    return g_strcmp0(property_value, "true") == 0;
+    return g_ascii_strcasecmp(property_value, "true") == 0;
 }
 
 gint8 b_device_service_property_provider_get_property_as_int8(BDeviceServicePropertyProvider *self,

--- a/api/c/test/provider/device-service-property-provider-test.c
+++ b/api/c/test/provider/device-service-property-provider-test.c
@@ -236,6 +236,16 @@ static void test_b_device_service_property_provider_get_property_as_bool(void **
         B_DEVICE_SERVICE_PROPERTY_PROVIDER(provider), name, defaultValue);
     assert_true(valueTest);
 
+    value = "True";
+    expect_function_call(__wrap_deviceServiceGetSystemProperty);
+    expect_string(__wrap_deviceServiceGetSystemProperty, name, name);
+    will_return(__wrap_deviceServiceGetSystemProperty, value);
+    will_return(__wrap_deviceServiceGetSystemProperty, true);
+
+    valueTest = b_device_service_property_provider_get_property_as_bool(
+        B_DEVICE_SERVICE_PROPERTY_PROVIDER(provider), name, defaultValue);
+    assert_true(valueTest);
+
     value = "false";
     expect_function_call(__wrap_deviceServiceGetSystemProperty);
     expect_string(__wrap_deviceServiceGetSystemProperty, name, name);


### PR DESCRIPTION
This change switches to case insensitive string comparison when reading boolean properties from the provider so clients using "True" or "TRUE" will properly map to true.

Refs: BARTON-263