### PR TITLE
feat: make Matter BLE Controller device name configurable

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -230,6 +230,11 @@ bcore_string_option(NAME BCORE_MATTER_DELEGATE_HEADER_PATHS
                   VALUE "${MATTER_PROVIDER_DELEGATE_PARENT_DIR}/delegates;
                          ${MATTER_DELEGATE_DEFAULT_DIR};")
 
+bcore_string_option(NAME BCORE_MATTER_BLE_CONTROLLER_DEVICE_NAME
+                    DEFINITION BARTON_CONFIG_MATTER_BLE_CONTROLLER_DEVICE_NAME
+                    DESCRIPTION "Name of the Matter BLE controller device."
+                    VALUE "BartonMatterBLEController")
+
 message(STATUS "- - - - - - - - - - - - - - - - ")
 
 message(STATUS "- - - - - - - - - - - - - - - - ")

--- a/core/src/subsystems/matter/Matter.cpp
+++ b/core/src/subsystems/matter/Matter.cpp
@@ -93,7 +93,7 @@ extern "C" {
 #define DISCOVER_ON_NETWORK_DEVICE_TIMEOUT_SECS 1
 
 #define BLE_CONTROLLER_ADAPTER_ID               0
-#define BLE_CONTROLLER_DEVICE_NAME              "Xfinity-Gateway"
+#define BLE_CONTROLLER_DEVICE_NAME              BARTON_CONFIG_MATTER_BLE_CONTROLLER_DEVICE_NAME
 
 #define LOCAL_NODE_ID_SYSTEM_PROPERTY_NAME      "localMatterNodeId"
 #define MATTER_RCA_SYSTEM_PROPERTY_NAME         "matterRCA"
@@ -189,7 +189,6 @@ bool Matter::Init(uint64_t accountId, std::string &&attestationTrustStorePath)
         return false;
     }
     icDebug("Local node ID: 0x%" PRIx64, myNodeId);
-
     mkdir_p(CHIP_BARTON_CONF_DIR, 0700);
 
     myFabricId = accountId;


### PR DESCRIPTION
Add BCORE_MATTER_BLE_CONTROLLER_DEVICE_NAME option to allow custom branding.

Refs: BARTON-253