### PR TITLE
fix: prevent segfaults in subsystemManager

### DIFF
--- a/core/src/subsystemManager.c
+++ b/core/src/subsystemManager.c
@@ -474,15 +474,14 @@ void subsystemManagerEnterLPM(void)
 {
     READ_LOCK_SCOPE(mutex);
 
-    if (subsystems)
-    {
-        SubsystemRegistration *registration = NULL;
-        MAP_FOREACH(
-            registration,
-            subsystems,
+    g_return_if_fail(subsystems != NULL);
 
-            if (registration->subsystem->onLPMStart != NULL) { registration->subsystem->onLPMStart(); });
-    }
+    SubsystemRegistration *registration = NULL;
+    MAP_FOREACH(
+        registration,
+        subsystems,
+
+        if (registration->subsystem->onLPMStart != NULL) { registration->subsystem->onLPMStart(); });
 }
 
 

--- a/core/src/subsystemManager.c
+++ b/core/src/subsystemManager.c
@@ -531,24 +531,22 @@ bool subsystemManagerIsReadyForDevices(void)
 
     READ_LOCK_SCOPE(mutex);
 
-    if (subsystems)
-    {
-        SubsystemRegistration *registration = NULL;
-        MAP_FOREACH(
-            registration,
-            subsystems,
+    g_return_val_if_fail(subsystems != NULL, false);
 
-            mutexLock(&registration->mtx);
-            bool ready = registration->ready;
-            mutexUnlock(&registration->mtx);
+    SubsystemRegistration *registration = NULL;
+    MAP_FOREACH(
+        registration,
+        subsystems,
 
-            if (ready == false) {
-                icInfo("Subsystem %s is not yet ready", registration->subsystem->name);
-                allReady = false;
-                break;
-            });
-    }
+        mutexLock(&registration->mtx);
+        bool ready = registration->ready;
+        mutexUnlock(&registration->mtx);
 
+        if (ready == false) {
+            icInfo("Subsystem %s is not yet ready", registration->subsystem->name);
+            allReady = false;
+            break;
+        });
 
     return allReady && allDriversStarted;
 }
@@ -562,22 +560,21 @@ bool subsystemManagerRestoreConfig(const char *tempRestoreDir, const char *dynam
 
     READ_LOCK_SCOPE(mutex);
 
-    if (subsystems)
-    {
-        SubsystemRegistration *registration = NULL;
-        MAP_FOREACH(
-            registration,
-            subsystems,
+    g_return_val_if_fail(subsystems != NULL, false);
 
-            if (registration->subsystem->onRestoreConfig != NULL) {
-                result &= registration->subsystem->onRestoreConfig(tempRestoreDir, dynamicConfigPath);
+    SubsystemRegistration *registration = NULL;
+    MAP_FOREACH(
+        registration,
+        subsystems,
 
-                if (!result)
-                {
-                    icWarn("failed for %s!", registration->subsystem->name);
-                }
-            });
-    }
+        if (registration->subsystem->onRestoreConfig != NULL) {
+            result &= registration->subsystem->onRestoreConfig(tempRestoreDir, dynamicConfigPath);
+
+            if (!result)
+            {
+                icWarn("failed for %s!", registration->subsystem->name);
+            }
+        });
 
     return result;
 }


### PR DESCRIPTION
The MAP_FOREACH macro was causing segmentation faults when accessing
uninitialized stack variables in the subsystem manager.

To fix:
- Initialize all local variables in the macro and add a null check on the
map parameter to prevent crashes.
- Add null checks in all public functions that use MAP_FOREACH to enforce
proper API contracts and improve error handling.