### PR TITLE
build: add fff to build environment

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -47,3 +47,8 @@ config/cmake/modules/CodeCoverage.cmake
 Copyright (c) 2012-2017, Lars Bilke
 All rights reserved.
 Licensed under the BSD-3 License
+
+Code borrowed from: https://github.com/meekrosoft/fff
+Copyright (c) 2010-2022 Michael Long (@meekrosoft)
+All rights reserved.
+Licensed under the MIT License

--- a/config/cmake/DependencyVersions.cmake
+++ b/config/cmake/DependencyVersions.cmake
@@ -26,6 +26,7 @@
 #
 
 include(BCoreFindPackage)
+include(BCoreFindIncludeDir)
 
 # These are intended to be set at the project level as other cmake refer to them.
 set(GLIB_MIN_VERSION 2.62.4)
@@ -50,6 +51,7 @@ bcore_find_package(NAME gio-2.0 MIN_VERSION ${GLIB_MIN_VERSION} REQUIRED)
 bcore_find_package(NAME gio-unix-2.0 MIN_VERSION ${GLIB_MIN_VERSION} REQUIRED)
 if(BUILD_TESTING)
     bcore_find_package(NAME cmocka MIN_VERSION ${CMOCKA_MIN_VERSION} REQUIRED)
+    bcore_find_include(FFF_INCLUDE_DIR fff.h fff "fff include directory" "")
 endif()
 # This is the version of libcurl that's linked against the older OpenSSL version
 set(ENV{PKG_CONFIG_PATH} "/usr/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")

--- a/config/cmake/modules/BCoreFindIncludeDir.cmake
+++ b/config/cmake/modules/BCoreFindIncludeDir.cmake
@@ -26,14 +26,15 @@
 #
 
 # This macro locates a required include directory containing a specific header
-# file and adds it to a specified include list.
+# file and optionally adds it to a specified include list.
 #
 # Parameters:
 #   VAR_NAME     - Name of the variable to store the found path
 #   HEADER_FILE  - Header file to search for (e.g., "file.h")
 #   PATH_SUFFIX  - Optional subdirectory to look in (can be empty string)
 #   DESCRIPTION  - Human-readable description used in error messages
-#   INCLUDE_LIST - Name of list variable to append the found path to
+#   INCLUDE_LIST - (Optional) Name of list variable to append the found path to.
+#                  Specify an empty string ("") to skip adding the path to any list.
 #
 macro(bcore_find_include VAR_NAME HEADER_FILE PATH_SUFFIX DESCRIPTION INCLUDE_LIST)
     find_path(${VAR_NAME} ${HEADER_FILE} PATH_SUFFIXES ${PATH_SUFFIX})
@@ -41,7 +42,9 @@ macro(bcore_find_include VAR_NAME HEADER_FILE PATH_SUFFIX DESCRIPTION INCLUDE_LI
     if (${VAR_NAME} STREQUAL "${VAR_NAME}-NOTFOUND")
         message(FATAL_ERROR "${DESCRIPTION} not found.")
     else()
-        list(APPEND ${INCLUDE_LIST} ${${VAR_NAME}})
+        if (NOT "${INCLUDE_LIST}" STREQUAL "")
+            list(APPEND ${INCLUDE_LIST} ${${VAR_NAME}})
+        endif()
     endif()
 
 endmacro()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -136,6 +136,7 @@ FROM base_builder AS third_party_builder
 ARG LINENOISE_GIT_TAG="d895173d679be70bcd8b23041fff3e458e1a3506"
 ARG OTBR_GIT_TAG="e851c2a80fb036e6987bedac399184a729f638d4"
 ARG LIBCERTIFIER_GIT_TAG="v2.2.2"
+ARG FFF_GIT_TAG="v1.1"
 
 # Copy over the third party patches
 ADD patches /tmp/patches
@@ -168,7 +169,10 @@ RUN apt-get update && apt-get -y upgrade && DEBIAN_FRONTEND='noninteractive' apt
 
 # Fake Function Framework (FFF)
 RUN cd /tmp && \
-    git clone --depth 1 https://github.com/meekrosoft/fff.git && \
+    git clone \
+    --depth 1 \
+    --branch ${FFF_GIT_TAG} \
+    https://github.com/meekrosoft/fff.git && \
     mkdir -p /usr/local/include/fff && \
     cp /tmp/fff/fff.h /usr/local/include/fff/ && \
     rm -rf /tmp/fff

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -136,7 +136,7 @@ FROM base_builder AS third_party_builder
 ARG LINENOISE_GIT_TAG="d895173d679be70bcd8b23041fff3e458e1a3506"
 ARG OTBR_GIT_TAG="e851c2a80fb036e6987bedac399184a729f638d4"
 ARG LIBCERTIFIER_GIT_TAG="v2.2.2"
-ARG FFF_GIT_TAG="v1.1"
+ARG FFF_GIT_TAG="5111c61e1ef7848e3afd3550044a8cf4405f4199"
 
 # Copy over the third party patches
 ADD patches /tmp/patches
@@ -168,11 +168,16 @@ RUN apt-get update && apt-get -y upgrade && DEBIAN_FRONTEND='noninteractive' apt
     socat
 
 # Fake Function Framework (FFF)
+#
+# NOTICE: Currently, FFF_GIT_TAG points to a specific commit SHA from master instead
+# of the v1.1 tag (from 2019) as significant development has been made since the
+# last official release.
+# This SHA represents a stable point in the master branch with all needed features.
 RUN cd /tmp && \
-    git clone \
-    --depth 1 \
-    --branch ${FFF_GIT_TAG} \
-    https://github.com/meekrosoft/fff.git && \
+    git clone --depth 1 https://github.com/meekrosoft/fff.git && \
+    cd fff && \
+    git fetch --depth 1 origin ${FFF_GIT_TAG} && \
+    git checkout ${FFF_GIT_TAG} && \
     mkdir -p /usr/local/include/fff && \
     cp /tmp/fff/fff.h /usr/local/include/fff/ && \
     rm -rf /tmp/fff

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -166,6 +166,13 @@ RUN apt-get update && apt-get -y upgrade && DEBIAN_FRONTEND='noninteractive' apt
     zlib1g-dev \
     socat
 
+# Fake Function Framework (FFF)
+RUN cd /tmp && \
+    git clone --depth 1 https://github.com/meekrosoft/fff.git && \
+    mkdir -p /usr/local/include/fff && \
+    cp /tmp/fff/fff.h /usr/local/include/fff/ && \
+    rm -rf /tmp/fff
+
 # 'gn' (generate ninja)
 RUN cd /tmp && \
     wget -O gn.zip "https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest" && \


### PR DESCRIPTION
Integrate the Fake Function Framework header-only library into our Docker build environment to enhance our mocking capabilities for unit tests.

- Add FFF installation to the Dockerfile
- Add FFF detection in CMake when tests are built
- Update NOTICE file with FFF attribution
- Update bcore_find_include to allow for an optional INCLUDE_LIST

This allows developers to use FFF's mocking capabilities alongside CMocka for more comprehensive unit testing.

Refs: BARTON-266