### PR TITLE
fix(driver): correct values for illuminance and humidity

### DIFF
--- a/api/c/public/private/zigbeeClusters/illuminanceMeasurementCluster.h
+++ b/api/c/public/private/zigbeeClusters/illuminanceMeasurementCluster.h
@@ -43,6 +43,17 @@ ZigbeeCluster *illuminanceMeasurementClusterCreate(const IlluminanceMeasurementC
 bool illuminanceMeasurementClusterGetMeasuredValue(uint64_t eui64, uint8_t endpointId, uint16_t *value);
 
 /**
+ * Converts the measured value from the illuminance measurement cluster to lux.  Zigbee
+ * encodes the illuminance in a logarithmic scale, so this function performs the conversion
+ * from the encoded value back to lux.
+ *
+ * @param measuredValue The measured value from the illuminance measurement cluster.
+ * @return The converted value in lux.
+ */
+uint32_t illuminanceMeasurementClusterConvertToLux(uint16_t measuredValue);
+
+
+/**
  * Helper to check for valid illuminance value.
  *
  * @param value illuminance value to check

--- a/api/c/public/private/zigbeeClusters/relativeHumidityMeasurementCluster.h
+++ b/api/c/public/private/zigbeeClusters/relativeHumidityMeasurementCluster.h
@@ -42,6 +42,8 @@ ZigbeeCluster *relativeHumidityMeasurementClusterCreate(const RelativeHumidityMe
 
 bool relativeHumidityMeasurementClusterGetMeasuredValue(uint64_t eui64, uint8_t endpointId, uint16_t *value);
 
+double relativeHumidityMeasurementClusterConvertToPercentage(uint16_t measuredValue);
+
 /**
  * Helper to check for valid value.
  *

--- a/core/deviceDrivers/zigbee/zigbeeClusters/illuminanceMeasurementCluster.c
+++ b/core/deviceDrivers/zigbee/zigbeeClusters/illuminanceMeasurementCluster.c
@@ -25,6 +25,7 @@
 // Created by Thomas Lea on 4/17/25.
 //
 
+#include <math.h>
 #define LOG_TAG "illuminanceMeasurementCluster"
 #define logFmt(fmt) "(%s): " fmt, __func__
 
@@ -94,6 +95,19 @@ bool illuminanceMeasurementClusterGetMeasuredValue(uint64_t eui64, uint8_t endpo
     }
 
     return result;
+}
+
+uint32_t illuminanceMeasurementClusterConvertToLux(uint16_t measuredValue)
+{
+    // 0 is a special case, it means "too low to measure"
+    if (measuredValue == 0)
+    {
+        return 0;
+    }
+    // From Zigbee Cluster Library Specification:
+    // MeasuredValue = 10,000 x log10 Illuminance + 1
+    // Therefore: Illuminance = 10 ^ ( (MeasuredValue - 1) / 10,000 )
+    return pow(10.0, ((double)measuredValue-1.0)/10000.0);
 }
 
 static bool configureCluster(ZigbeeCluster *ctx, const DeviceConfigurationContext *configContext)

--- a/core/deviceDrivers/zigbee/zigbeeClusters/relativeHumidityMeasurementCluster.c
+++ b/core/deviceDrivers/zigbee/zigbeeClusters/relativeHumidityMeasurementCluster.c
@@ -96,6 +96,12 @@ bool relativeHumidityMeasurementClusterGetMeasuredValue(uint64_t eui64, uint8_t 
     return result;
 }
 
+double relativeHumidityMeasurementClusterConvertToPercentage(uint16_t measuredValue)
+{
+    // Zigbee encodes the relative humidity in units of .01% relative humidity, e.g. 5000 = 50.00% RH.
+    return (double)measuredValue / 100.0;
+}
+
 static bool configureCluster(ZigbeeCluster *ctx, const DeviceConfigurationContext *configContext)
 {
     bool result = true;

--- a/core/deviceDrivers/zigbee/zigbeeOccupancySensorDeviceDriver.c
+++ b/core/deviceDrivers/zigbee/zigbeeOccupancySensorDeviceDriver.c
@@ -51,6 +51,8 @@
 
 #define OCCUPANCY_SENSOR_DEVICE_ID 0x0107
 
+#define HUMIDITY_FORMAT_STRING     "%.2f"
+
 /* ZigbeeDriverCommonCallbacks */
 static bool fetchInitialResourceValues(ZigbeeDriverCommon *ctx,
                                        icDevice *device,
@@ -159,7 +161,7 @@ static bool fetchInitialResourceValues(ZigbeeDriverCommon *ctx,
             g_autofree char *illuminanceStr = NULL;
             if (illuminanceMeasurementClusterIsValueValid(illuminance))
             {
-                illuminanceStr = g_strdup_printf("%" PRIu16, illuminance);
+                illuminanceStr = g_strdup_printf("%" PRIu32, illuminanceMeasurementClusterConvertToLux(illuminance));
             }
             initialResourceValuesPutEndpointValue(initialResourceValues,
                                                   epName,
@@ -175,7 +177,8 @@ static bool fetchInitialResourceValues(ZigbeeDriverCommon *ctx,
             g_autofree char *humidityStr = NULL;
             if (relativeHumidityMeasurementClusterIsValueValid(humidity))
             {
-                humidityStr = g_strdup_printf("%" PRIu16, humidity);
+                humidityStr = g_strdup_printf(HUMIDITY_FORMAT_STRING,
+                                              relativeHumidityMeasurementClusterConvertToPercentage(humidity));
             }
             initialResourceValuesPutEndpointValue(initialResourceValues,
                                                   epName,
@@ -312,7 +315,8 @@ static void illuminanceMeasuredValueUpdated(void *ctx, uint64_t eui64, uint8_t e
     g_autofree char *illuminanceStr = NULL;
     if (illuminanceMeasurementClusterIsValueValid(value))
     {
-        illuminanceStr = g_strdup_printf("%" PRIu16, value);
+
+        illuminanceStr = g_strdup_printf("%" PRIu32, illuminanceMeasurementClusterConvertToLux(value));
     }
     updateResource(deviceId, epName, SENSOR_PROFILE_RESOURCE_ILLUMINANCE, illuminanceStr, NULL);
 }
@@ -325,7 +329,8 @@ static void relativeHumidityMeasuredValueUpdated(void *ctx, uint64_t eui64, uint
     g_autofree char *humidityStr = NULL;
     if (relativeHumidityMeasurementClusterIsValueValid(value))
     {
-        humidityStr = g_strdup_printf("%" PRIu16, value);
+        humidityStr =
+            g_strdup_printf(HUMIDITY_FORMAT_STRING, relativeHumidityMeasurementClusterConvertToPercentage(value));
     }
     updateResource(deviceId, epName, SENSOR_PROFILE_RESOURCE_HUMIDITY, humidityStr, NULL);
 }


### PR DESCRIPTION
Illuminance and humidity were being reported using the Zigbee encoded values rather than more user friendly units.

Refs: BARTON-268