### PR TITLE
docs: replace old `brtn` usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd BartonCore
 ./dockerw ./build.sh
 
 # Run the reference app which includes interactive CLI
-./dockerw build/reference/barton-core-reference
+./dockerw build/reference/barton-core-reference -z
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd BartonCore
 ./dockerw ./build.sh
 
 # Run the reference app which includes interactive CLI
-./dockerw build/reference/brtn-ds-reference
+./dockerw build/reference/barton-core-reference
 ```
 
 ## Documentation

--- a/testing/py_test.sh
+++ b/testing/py_test.sh
@@ -26,7 +26,7 @@
 # Created by Kevin Funderburg on 12/17/2024
 #
 
-# In order for pytests to run successfully with libbrtnDeviceSericeShared.so compiled
+# In order for pytests to run successfully with libBartonCore.so compiled
 # with AddressSanitizer, libasan.so must be preloaded. This script is a wrapper around
 # pytest to handle setting the LD_PRELOAD environment variable and passing any extra args
 # to pytest. Use this script if you want to execute any pytests on the command line to ensure


### PR DESCRIPTION
Some references to the original naming convention of `brtn` were lingering around in documentation and comments. Swap these usages out for the newer naming convention.