### PR TITLE
fix(matter): support ARL feature as optional

### DIFF
--- a/core/src/subsystems/matter/AccessRestrictionProvider.h
+++ b/core/src/subsystems/matter/AccessRestrictionProvider.h
@@ -38,7 +38,7 @@
 
 namespace barton
 {
-
+#if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
     class AccessRestrictionProvider : public chip::Access::AccessRestrictionProvider
     {
     public:
@@ -59,9 +59,8 @@ namespace barton
                 .token = token, .fabricIndex = fabricIndex};
             chip::EventNumber eventNumber;
             ReturnErrorOnFailure(chip::app::LogEvent(event, chip::kRootEndpointId, eventNumber));
-
             return CHIP_NO_ERROR;
         }
     };
-
+#endif
 } // namespace barton

--- a/core/src/subsystems/matter/Matter.cpp
+++ b/core/src/subsystems/matter/Matter.cpp
@@ -316,7 +316,9 @@ bool Matter::Start()
         // We need to set DeviceInfoProvider before Server::Init to setup the storage of DeviceInfoProvider properly.
         chip::DeviceLayer::SetDeviceInfoProvider(&deviceInfoProvider);
 
+#if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
         serverInitParams.accessRestrictionProvider = &accessRestrictionProvider;
+#endif
 
         if ((err = Server::GetInstance().Init(serverInitParams)) != CHIP_NO_ERROR)
         {
@@ -1366,7 +1368,7 @@ bool Matter::OpenCommissioningWindow(chip::NodeId nodeId,
 
 bool Matter::SetAccessRestrictionList()
 {
-#if ENABLE_ARLS_FOR_TESTING
+#if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS && ENABLE_ARLS_FOR_TESTING
     bool success = false;
 
     //TODO make these real.  The restrictions now are just for certification testing and only block some attribute that wont cause cert issue
@@ -1403,6 +1405,7 @@ bool Matter::ClearAccessRestrictionList()
 {
     bool success = true;
 
+#if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
     icWarn("Certification: Clearing AccessRestrictions");
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
@@ -1418,6 +1421,7 @@ bool Matter::ClearAccessRestrictionList()
     }
 
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+#endif
 
     return success;
 }

--- a/core/src/subsystems/matter/Matter.h
+++ b/core/src/subsystems/matter/Matter.h
@@ -324,6 +324,8 @@ namespace barton
         std::atomic<State> state = {State::stopped};
 
         SessionMessageHandler sessionMessageHandler;
+#if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
         AccessRestrictionProvider accessRestrictionProvider;
+#endif
     };
 } // namespace barton


### PR DESCRIPTION
If the Matter SDK is compiled without Acccess Restriction List (ARL) support, then we must not try and enable related parts in our code or it wont build.