### PR TITLE
feat: implement subsystem reference counting

### DIFF
--- a/core/src/subsystemManager.h
+++ b/core/src/subsystemManager.h
@@ -123,6 +123,29 @@ typedef struct Subsystem
     uint16_t version;
 } Subsystem;
 
+/*
+ * Create a new refcounted subsystem
+ */
+Subsystem *createSubsystem(void);
+
+/**
+ * Acquires a pointer to the reference counted Subsystem, with its reference count increased.
+ *
+ * @param subsystem pointer to reference counted Subsystem
+ */
+Subsystem *acquireSubsystem(Subsystem *subsystem);
+
+/**
+ * Release a subsystem. This will decrement the refcount and destroy the subsystem if the refcount reaches zero.
+ *
+ * @param subsystem pointer to reference counted Subsystem
+ */
+void releaseSubsystem(Subsystem *subsystem);
+
+/*
+ * Convenience macro to declare a scope bound Subsystem
+ */
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(Subsystem, releaseSubsystem)
 
 /*
  * Callback for when all subsystems are ready for devices

--- a/core/src/subsystems/matter/matterSubsystem.cpp
+++ b/core/src/subsystems/matter/matterSubsystem.cpp
@@ -121,17 +121,18 @@ static void accountIdChanged(const gchar *accountId);
 
 __attribute__((constructor)) static void registerSubsystem()
 {
-    static struct Subsystem matterSubsystem = {.migrate = matterSubsystemMigrate,
-                                               .initialize = matterSubsystemInitialize,
-                                               .shutdown = matterSubsystemShutdown,
-                                               .onAllServicesAvailable = matterSubsystemAllServicesAvailable,
-                                               .onRestoreConfig = matterSubsystemRestoreConfig,
-                                               .onPostRestoreConfig = matterSubsystemPostRestoreConfig,
-                                               .getStatusJson = getStatusJson,
-                                               .name = MATTER_SUBSYSTEM_NAME,
-                                               .version = MATTER_SUBSYSTEM_VERSION};
+    g_autoptr(Subsystem) matterSubsystem = createSubsystem();
+    matterSubsystem->migrate = matterSubsystemMigrate;
+    matterSubsystem->initialize = matterSubsystemInitialize;
+    matterSubsystem->shutdown = matterSubsystemShutdown;
+    matterSubsystem->onAllServicesAvailable = matterSubsystemAllServicesAvailable;
+    matterSubsystem->onRestoreConfig = matterSubsystemRestoreConfig;
+    matterSubsystem->onPostRestoreConfig = matterSubsystemPostRestoreConfig;
+    matterSubsystem->getStatusJson = getStatusJson;
+    matterSubsystem->name = MATTER_SUBSYSTEM_NAME;
+    matterSubsystem->version = MATTER_SUBSYSTEM_VERSION;
 
-    subsystemManagerRegister(&matterSubsystem);
+    subsystemManagerRegister(matterSubsystem);
 }
 
 static char *getAccountId()

--- a/core/src/subsystems/thread/threadSubsystem.cpp
+++ b/core/src/subsystems/thread/threadSubsystem.cpp
@@ -81,14 +81,15 @@ static bool migrate(uint16_t oldVersion, uint16_t newVersion);
 
 __attribute__((constructor)) __attribute__((used)) static void registerSubsystem(void)
 {
-    static Subsystem threadSubsystem = {.migrate = migrate,
-                                        .initialize = initialize,
-                                        .shutdown = shutdown,
-                                        .getStatusJson = getStatusJson,
-                                        .name = THREAD_SUBSYSTEM_NAME,
-                                        .version = THREAD_SUBSYSTEM_VERSION};
+    g_autoptr(Subsystem) threadSubsystem = createSubsystem();
+    threadSubsystem->migrate = migrate;
+    threadSubsystem->initialize = initialize;
+    threadSubsystem->shutdown = shutdown;
+    threadSubsystem->getStatusJson = getStatusJson;
+    threadSubsystem->name = THREAD_SUBSYSTEM_NAME;
+    threadSubsystem->version = THREAD_SUBSYSTEM_VERSION;
 
-    subsystemManagerRegister(&threadSubsystem);
+    subsystemManagerRegister(threadSubsystem);
 }
 
 /*

--- a/core/src/subsystems/zigbee/zigbeeSubsystem.c
+++ b/core/src/subsystems/zigbee/zigbeeSubsystem.c
@@ -427,21 +427,20 @@ static cJSON *getStatusJson(void);
 
 __attribute__((constructor)) static void registerSubsystem(void)
 {
-    static Subsystem zigbeeSubsystem = {
-        .name = ZIGBEE_SUBSYSTEM_NAME,
-        .onPostRestoreConfig = zigbeeSubsystemPostRestoreConfig,
-        .onAllServicesAvailable = zigbeeSubsystemAllServicesAvailable,
-        .onAllDriversStarted = zigbeeSubsystemAllDriversStarted,
-        .onRestoreConfig = zigbeeSubsystemRestoreConfig,
-        .onLPMStart = zigbeeSubsystemEnterLPM,
-        .onLPMEnd = zigbeeSubsystemExitLPM,
-        .setOtaUpgradeDelay = zigbeeSubsystemSetOtaUpgradeDelay,
-        .initialize = zigbeeSubsystemInitialize,
-        .shutdown = zigbeeSubsystemShutdown,
-        .getStatusJson = getStatusJson,
-    };
+    g_autoptr(Subsystem) zigbeeSubsystem = createSubsystem();
+    zigbeeSubsystem->name = ZIGBEE_SUBSYSTEM_NAME;
+    zigbeeSubsystem->onPostRestoreConfig = zigbeeSubsystemPostRestoreConfig;
+    zigbeeSubsystem->onAllServicesAvailable = zigbeeSubsystemAllServicesAvailable;
+    zigbeeSubsystem->onAllDriversStarted = zigbeeSubsystemAllDriversStarted;
+    zigbeeSubsystem->onRestoreConfig = zigbeeSubsystemRestoreConfig;
+    zigbeeSubsystem->onLPMStart = zigbeeSubsystemEnterLPM;
+    zigbeeSubsystem->onLPMEnd = zigbeeSubsystemExitLPM;
+    zigbeeSubsystem->setOtaUpgradeDelay = zigbeeSubsystemSetOtaUpgradeDelay;
+    zigbeeSubsystem->initialize = zigbeeSubsystemInitialize;
+    zigbeeSubsystem->shutdown = zigbeeSubsystemShutdown;
+    zigbeeSubsystem->getStatusJson = getStatusJson;
 
-    subsystemManagerRegister(&zigbeeSubsystem);
+    subsystemManagerRegister(zigbeeSubsystem);
 }
 
 static void waitForInitialZigbeeCoreStartup(void)

--- a/core/test/src/subsystems/subsystemManagerTest.c
+++ b/core/test/src/subsystems/subsystemManagerTest.c
@@ -128,15 +128,15 @@ static cJSON *mockGetStatusJson(void)
     return cJSON_Duplicate(fixture, 1);
 }
 
-static Subsystem *createSubsystem(const char *name)
+static Subsystem *createTestSubsystem(const char *name)
 {
-    Subsystem *subsystem = calloc(1, sizeof(Subsystem));
+    Subsystem *subsystem = createSubsystem();
 
     subsystem->name = name;
     subsystem->initialize = myInitialize;
     subsystem->migrate = myMigrate;
 
-    return subsystem;
+    return g_steal_pointer(&subsystem);
 }
 
 static void assertRegisteredSubsystemCount(int expectedCount)
@@ -164,10 +164,7 @@ void test_subsystem_migration(void **state)
 
     static const char *subsystemName = "mySubsystem";
 
-    scoped_generic Subsystem *mySubsystem = calloc(1, sizeof(Subsystem));
-    mySubsystem->initialize = myInitialize;
-    mySubsystem->migrate = myMigrate;
-    mySubsystem->name = subsystemName;
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     subsystemManagerRegister(mySubsystem);
 
     const char *zero = "0";
@@ -281,21 +278,19 @@ void test_subsystemManagerRegister(void **state)
 
     static const char *subsystemName = "mySubsystem";
 
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
-    mySubsystem->initialize = NULL;
-    mySubsystem->name = NULL;
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(NULL);
 
     // Case 1: Passing NULL subsystem
     subsystemManagerRegister(NULL);
     assertRegisteredSubsystemCount(0);
 
     // Case 2: Subsystem with NULL initialize function
+    mySubsystem->initialize = NULL;
     subsystemManagerRegister(mySubsystem);
     assertRegisteredSubsystemCount(0);
 
     // Case 3: Subsystem with NULL name
     mySubsystem->initialize = myInitialize;
-    mySubsystem->name = NULL;
     subsystemManagerRegister(mySubsystem);
     assertRegisteredSubsystemCount(0);
 
@@ -319,7 +314,7 @@ void test_subsystemManagerGetRegisteredSubsystems(void **state)
 
     // Case 2: Single subsystem registered
     static const char *subsystemName1 = "Subsystem1";
-    scoped_generic Subsystem *subsystem1 = createSubsystem(subsystemName1);
+    g_autoptr(Subsystem) subsystem1 = createTestSubsystem(subsystemName1);
     subsystemManagerRegister(subsystem1);
 
     assertRegisteredSubsystemCount(1);
@@ -327,7 +322,7 @@ void test_subsystemManagerGetRegisteredSubsystems(void **state)
 
     // Case 3: Multiple subsystems registered
     static const char *subsystemName2 = "Subsystem2";
-    scoped_generic Subsystem *subsystem2 = createSubsystem(subsystemName2);
+    g_autoptr(Subsystem) subsystem2 = createTestSubsystem(subsystemName2);
     subsystemManagerRegister(subsystem2);
 
     assertRegisteredSubsystemCount(2);
@@ -347,7 +342,7 @@ void test_subsystemManagerGetSubsystemStatusJson(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "zigbee";
-    scoped_generic Subsystem *subsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) subsystem = createTestSubsystem(subsystemName);
 
     // Case 1: Subsystem with NULL getStatusJson function
     subsystem->getStatusJson = NULL;
@@ -391,7 +386,7 @@ void test_subsystemManagerShutdown(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
 
     // Case 1: Subsystem with NULL shutdown function
     subsystemManagerRegister(mySubsystem);
@@ -413,7 +408,7 @@ static void test_subsystemManagerAllDriversStarted(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     mySubsystem->onAllDriversStarted = NULL;
 
     // Case 1: Subsystem with NULL onAllDriversStarted function
@@ -436,7 +431,7 @@ static void test_subsystemManagerAllServicesAvailable(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     mySubsystem->onAllServicesAvailable = NULL;
 
     // Case 1: Subsystem with NULL onAllServicesAvailable function
@@ -459,7 +454,7 @@ static void test_subsystemManagerPostRestoreConfig(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     mySubsystem->onPostRestoreConfig = NULL;
 
     // Case 1: Subsystem with NULL postRestoreConfig function
@@ -482,7 +477,7 @@ static void test_subsystemManagerSetOtaUpgradeDelay(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     mySubsystem->setOtaUpgradeDelay = NULL;
 
     // Case 1: Subsystem with NULL setOtaUpgradeDelay function
@@ -518,7 +513,7 @@ static void test_subsystemManagerExitLPM(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     mySubsystem->onLPMEnd = NULL;
 
     // Case 1: Subsystem with NULL onLPMEnd function
@@ -541,7 +536,7 @@ static void test_subsystemManagerEnterLPM(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
 
     // Case 1: Subsystem with NULL onLPMStart function
     subsystemManagerRegister(mySubsystem);
@@ -564,7 +559,7 @@ static void test_subsystemManagerIsSubsystemReady(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     mySubsystem->version = 0;
     const char *zero = "0";
     subsystemManagerRegister(mySubsystem);
@@ -609,7 +604,7 @@ static void test_subsystemManagerRestoreConfig(void **state)
     unregisterSubsystems();
 
     static const char *subsystemName = "mySubsystem";
-    scoped_generic Subsystem *mySubsystem = createSubsystem(subsystemName);
+    g_autoptr(Subsystem) mySubsystem = createTestSubsystem(subsystemName);
     mySubsystem->onRestoreConfig = NULL;
     const char *config = "config";
     const char *restoreConfig = "restoreConfig";


### PR DESCRIPTION
Stacked PRs:
 * #50
 * __->__#49


--- --- ---

### feat: implement subsystem reference counting


Refactor Subsystem and SubsystemRegistration objects to use GLib's atomic
reference counting API. This makes subsystem memory management more intuitive
and safer through explicit ownership transfers.

Memory safety is improved by using g_atomic_rc_box functions and automatic
cleanup for deterministic object lifetime.

Refs: BARTON-267
