### PR TITLE
feat: redesign subsystemManager with clear lifecycle

### DIFF
--- a/core/src/subsystemManager.h
+++ b/core/src/subsystemManager.h
@@ -210,8 +210,14 @@ void subsystemManagerEnterLPM(void);
 void subsystemManagerExitLPM(void);
 
 /**
- * Register your subsystem
- * @param subsystem A Subsystem that h
+ * Register your subsystem with the subsystem manager.
+ *
+ * Subsystems can be registered at any time - the subsystem manager will handle
+ * registration appropriately regardless of its current lifecycle state. This allows
+ * subsystems to register themselves during module loading (e.g., via
+ * __attribute__((constructor)) functions) without concern for initialization order.
+ *
+ * @param subsystem A Subsystem that has been fully initialized
  */
 void subsystemManagerRegister(Subsystem *subsystem);
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#50
 * #49


--- --- ---

### feat: redesign subsystemManager with clear lifecycle


Refactor subsystemManager to implement a consistent initialize/shutdown
lifecycle. Introduce a preregistration mechanism for subsystems to register
before manager initialization. This separates registration from
initialization and allows proper sequencing.

- Manage subsystem registration timing during initialization
- Improve subsystemManager tests with proper setup/teardown and
  auto-registered subsystem cleanup
- Add proper documentation for preregistration in subsystem interfaces

Refs: BARTON-267
