### PR TITLE
fix(thread): fix retrieving device role

### DIFF
--- a/core/src/subsystems/thread/OpenThreadClient.cpp
+++ b/core/src/subsystems/thread/OpenThreadClient.cpp
@@ -336,6 +336,10 @@ namespace barton
         {
             icError("Failed to get device role. Error = %d", (int) error);
         }
+        else
+        {
+            retVal = TranslateOTBRDeviceRole(otbrDeviceRole);
+        }
 
         return retVal;
     }


### PR DESCRIPTION
Coding error skipped translating and returning the OTBR device role to the caller.

Refs: BARTON-272