### PR TITLE
build: abstract Matter extension types for future expandability

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -209,9 +209,9 @@ bcore_string_option(NAME BCORE_MATTER_LIB
 # Default selected implementations still need to be set up in below lists.
 include(BCoreMatterHelper)
 
-set(MATTER_PROVIDER_DELEGATE_PARENT_DIR "${PROJECT_SOURCE_DIR}/core/src/subsystems/matter")
-set(MATTER_PROVIDER_DEFAULT_DIR "${MATTER_PROVIDER_DELEGATE_PARENT_DIR}/providers/default")
-set(MATTER_DELEGATE_DEFAULT_DIR "${MATTER_PROVIDER_DELEGATE_PARENT_DIR}/delegates/default")
+set(MATTER_EXTENSION_PARENT_DIR "${PROJECT_SOURCE_DIR}/core/src/subsystems/matter")
+set(MATTER_PROVIDER_DEFAULT_DIR "${MATTER_EXTENSION_PARENT_DIR}/providers/default")
+set(MATTER_DELEGATE_DEFAULT_DIR "${MATTER_EXTENSION_PARENT_DIR}/delegates/default")
 
 bcore_string_option(NAME BCORE_MATTER_PROVIDER_IMPLEMENTATIONS
                   DEFINITION BARTON_CONFIG_MATTER_PROVIDER_IMPLEMENTATIONS

--- a/config/cmake/platforms/dev/linux.cmake
+++ b/config/cmake/platforms/dev/linux.cmake
@@ -37,11 +37,13 @@ include(${CMAKE_SOURCE_DIR}/config/cmake/modules/BCoreMatterHelper.cmake)
 
 set(BCORE_MATTER_USE_RANDOM_PORT ON CACHE BOOL "Use random port")
 
-bcore_matter_helper_delegate_add_implementation(
+bcore_matter_helper_add_implementation(
+    EXTENSION_TYPE DELEGATE
     DEV SelfSignedCertifierOperationalCredentialsIssuer
 )
 
-bcore_matter_helper_provider_add_implementation(
+bcore_matter_helper_add_implementation(
+    EXTENSION_TYPE PROVIDER
     DEFAULT DefaultCommissionableDataProvider
     DEV BartonTestDACProvider
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -85,11 +85,13 @@ if (BCORE_MATTER)
 
     add_compile_definitions(CHIP_HAVE_CONFIG_H=1)
 
-    bcore_matter_helper_provider_get_implementations(
+    bcore_matter_helper_get_implementations(
+        EXTENSION_TYPE PROVIDER
         OUTPUT MATTER_PROVIDER_IMPLEMENTATIONS
     )
 
-    bcore_matter_helper_delegate_get_implementations(
+    bcore_matter_helper_get_implementations(
+        EXTENSION_TYPE DELEGATE
         OUTPUT MATTER_DELEGATE_IMPLEMENTATIONS
     )
 
@@ -125,11 +127,13 @@ if (BCORE_MATTER)
 
     bcore_find_package(NAME jsoncpp MIN_VERSION ${JSONCPP_MIN_VERSION} REQUIRED)
 
-    bcore_matter_helper_provider_get_header_paths(
+    bcore_matter_helper_get_header_paths(
+        EXTENSION_TYPE PROVIDER
         OUTPUT MATTER_PROVIDER_HEADER_PATHS
     )
 
-    bcore_matter_helper_delegate_get_header_paths(
+    bcore_matter_helper_get_header_paths(
+        EXTENSION_TYPE DELEGATE
         OUTPUT MATTER_DELEGATE_HEADER_PATHS
     )
 


### PR DESCRIPTION
Stacked PRs:
 * #55
 * __->__#54


--- --- ---

### build: abstract Matter extension types for future expandability


Refactor BCoreMatterHelper.cmake to use a more generic approach for handling
different extension types (providers, delegates). This enables easy addition
of new extension types like helpers in the future.

Key changes:
- Replace specialized provider/delegate functions with type-parametrized versions
- Add generic getter functions for implementations and header paths
- Reduce code duplication through shared implementation patterns

This abstraction simplifies maintenance and makes the module more flexible
for future extension types.