### PR TITLE
feat(matter): add BartonOperationalKeystore

### DIFF
--- a/config/cmake/modules/BCoreMatterHelper.cmake
+++ b/config/cmake/modules/BCoreMatterHelper.cmake
@@ -33,7 +33,7 @@ include(CMakeParseArguments)
 # from that point on. Users may define the public options in initial cache files or passed
 # as CLI options, but should use this module at any point after that.
 
-set(MATTER_EXTENSION_TYPES "PROVIDER;DELEGATE")
+set(MATTER_EXTENSION_TYPES "PROVIDER;DELEGATE;SERVICE")
 
 # Module may be included from a cmake file that hasn't called `project` yet (likely an initial cache)
 # Figure out the path relative to the current file as that works in all cases.
@@ -69,10 +69,13 @@ set(MATTER_HELPER_PROVIDER_DEPENDENCIES
 set(MATTER_HELPER_DELEGATE_DEPENDENCIES
 )
 
+set(MATTER_HELPER_SERVICE_DEPENDENCIES
+)
+
 # Private
 # Validates that the provided extension type is one of the allowed types
 # Usage:
-# _matter_helper_validate_extension_type(EXTENSION_TYPE "PROVIDER|DELEGATE")
+# _matter_helper_validate_extension_type(EXTENSION_TYPE "PROVIDER|DELEGATE|SERVICE")
 function(_matter_helper_validate_extension_type)
     set(oneValueArgs EXTENSION_TYPE)
 
@@ -219,7 +222,7 @@ endfunction()
 
 # Add a header path to the list of search paths for the specified extension type.
 # Usage:
-# bcore_matter_helper_add_header_path(EXTENSION_TYPE "PROVIDER|DELEGATE" PATH "/Path/To/Header")
+# bcore_matter_helper_add_header_path(EXTENSION_TYPE "PROVIDER|DELEGATE|SERVICE" PATH "/Path/To/Header")
 function(bcore_matter_helper_add_header_path)
     set(oneValueArgs EXTENSION_TYPE PATH)
 
@@ -328,7 +331,7 @@ endfunction()
 #
 # Usage:
 # bcore_matter_helper_add_implementation(
-#     EXTENSION_TYPE "PROVIDER|DELEGATE"
+#     EXTENSION_TYPE "PROVIDER|DELEGATE|SERVICE"
 #     DEFAULT "ExtensionName1" "ExtensionName2"
 #     DEV "DevExtensionName1" "DevExtensionName2"
 #     CUSTOM "/Path/To/CustomImplementation1.cpp" "/Path/To/CustomImplementation2.cpp"
@@ -377,7 +380,7 @@ endfunction()
 
 # Get the list of implementations for the specified extension type.
 # Usage:
-# bcore_matter_helper_get_implementations(EXTENSION_TYPE "PROVIDER|DELEGATE" OUTPUT variable_name)
+# bcore_matter_helper_get_implementations(EXTENSION_TYPE "PROVIDER|DELEGATE|SERVICE" OUTPUT variable_name)
 # Example:
 # bcore_matter_helper_get_implementations(EXTENSION_TYPE PROVIDER OUTPUT providerImpls)
 function(bcore_matter_helper_get_implementations)
@@ -398,7 +401,7 @@ endfunction()
 
 # Get the list of header paths for the specified extension type.
 # Usage:
-# bcore_matter_helper_get_header_paths(EXTENSION_TYPE "PROVIDER|DELEGATE" OUTPUT variable_name)
+# bcore_matter_helper_get_header_paths(EXTENSION_TYPE "PROVIDER|DELEGATE|SERVICE" OUTPUT variable_name)
 # Example:
 # bcore_matter_helper_get_header_paths(EXTENSION_TYPE PROVIDER OUTPUT providerHeaderPaths)
 function(bcore_matter_helper_get_header_paths)

--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -212,6 +212,7 @@ include(BCoreMatterHelper)
 set(MATTER_EXTENSION_PARENT_DIR "${PROJECT_SOURCE_DIR}/core/src/subsystems/matter")
 set(MATTER_PROVIDER_DEFAULT_DIR "${MATTER_EXTENSION_PARENT_DIR}/providers/default")
 set(MATTER_DELEGATE_DEFAULT_DIR "${MATTER_EXTENSION_PARENT_DIR}/delegates/default")
+set(MATTER_SERVICE_DEFAULT_DIR "${MATTER_EXTENSION_PARENT_DIR}/services/default")
 
 bcore_string_option(NAME BCORE_MATTER_PROVIDER_IMPLEMENTATIONS
                   DEFINITION BARTON_CONFIG_MATTER_PROVIDER_IMPLEMENTATIONS
@@ -224,6 +225,11 @@ bcore_string_option(NAME BCORE_MATTER_DELEGATE_IMPLEMENTATIONS
                   DESCRIPTION "List of paths to source files that implement Matter delegate interfaces."
                   VALUE "${MATTER_DELEGATE_DEFAULT_DIR}/CertifierOperationalCredentialsIssuer.cpp")
 
+bcore_string_option(NAME BCORE_MATTER_SERVICE_IMPLEMENTATIONS
+                  DEFINITION BARTON_CONFIG_MATTER_SERVICE_IMPLEMENTATIONS
+                  DESCRIPTION "List of paths to source files that implement Matter service interfaces."
+                  VALUE "${MATTER_SERVICE_DEFAULT_DIR}/DefaultOperationalKeystore.cpp")
+
 bcore_string_option(NAME BCORE_MATTER_PROVIDER_HEADER_PATHS
                   DEFINITION BARTON_CONFIG_MATTER_PROVIDER_HEADER_PATHS
                   DESCRIPTION "List of paths to directories containing matter provider header files.")
@@ -231,6 +237,10 @@ bcore_string_option(NAME BCORE_MATTER_PROVIDER_HEADER_PATHS
 bcore_string_option(NAME BCORE_MATTER_DELEGATE_HEADER_PATHS
                   DEFINITION BARTON_CONFIG_MATTER_DELEGATE_HEADER_PATHS
                   DESCRIPTION "List of paths to directories containing matter delegate header files")
+
+bcore_string_option(NAME BCORE_MATTER_SERVICE_HEADER_PATHS
+                  DEFINITION BARTON_CONFIG_MATTER_SERVICE_HEADER_PATHS
+                  DESCRIPTION "List of paths to directories containing matter service header files")
 
 bcore_string_option(NAME BCORE_MATTER_BLE_CONTROLLER_DEVICE_NAME
                     DEFINITION BARTON_CONFIG_MATTER_BLE_CONTROLLER_DEVICE_NAME

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -95,10 +95,16 @@ if (BCORE_MATTER)
         OUTPUT MATTER_DELEGATE_IMPLEMENTATIONS
     )
 
+    bcore_matter_helper_get_implementations(
+        EXTENSION_TYPE SERVICE
+        OUTPUT MATTER_SERVICE_IMPLEMENTATIONS
+    )
+
     list(APPEND SOURCES
         ${matterSubSrc}
         ${MATTER_PROVIDER_IMPLEMENTATIONS}
         ${MATTER_DELEGATE_IMPLEMENTATIONS}
+        ${MATTER_SERVICE_IMPLEMENTATIONS}
         ${matterDriversSrc}
         ${matterSrc}
         "src/subsystems/matter/providers/BartonDeviceInstanceInfoProvider.cpp" # This provider is always required
@@ -137,10 +143,17 @@ if (BCORE_MATTER)
         OUTPUT MATTER_DELEGATE_HEADER_PATHS
     )
 
+    bcore_matter_helper_get_header_paths(
+        EXTENSION_TYPE SERVICE
+        OUTPUT MATTER_SERVICE_HEADER_PATHS
+    )
+
     list(APPEND XTRA_INCLUDES
         ${OPENSSL_INCLUDE_DIRS}
         ${MATTER_PROVIDER_HEADER_PATHS}
-        ${MATTER_DELEGATE_HEADER_PATHS})
+        ${MATTER_DELEGATE_HEADER_PATHS}
+        ${MATTER_SERVICE_HEADER_PATHS}
+    )
 
     list(APPEND XTRA_LIBS ${BCORE_MATTER_LIB} ${OPENSSL_LINK_LIBRARIES} certifier jsoncpp)
     link_directories(${CMAKE_BINARY_DIR}/matter-install/lib)

--- a/core/src/subsystems/matter/Matter.cpp
+++ b/core/src/subsystems/matter/Matter.cpp
@@ -86,6 +86,7 @@ extern "C" {
 #include "BartonDeviceInstanceInfoProvider.hpp"
 #include "BartonMatterDelegateRegistry.hpp"
 #include "BartonMatterProviderRegistry.hpp"
+#include "BartonMatterServiceRegistry.hpp"
 #include "Matter.h"
 #include "credentials/attestation_verifier/DeviceAttestationVerifier.h"
 
@@ -230,7 +231,7 @@ bool Matter::Init(uint64_t accountId, std::string &&attestationTrustStorePath)
         return false;
     }
 
-    operationalKeystore = std::make_unique<chip::PersistentStorageOperationalKeystore>();
+    operationalKeystore = BartonMatterServiceRegistry::Instance().GetBartonOperationalKeystore();
     err = operationalKeystore->Init(&storageDelegate);
 
     if (!ChipError::IsSuccess(err))

--- a/core/src/subsystems/matter/Matter.h
+++ b/core/src/subsystems/matter/Matter.h
@@ -30,6 +30,7 @@
 #include "AccessRestrictionProvider.h"
 #include "BartonOperationalCredentialsDelegate.hpp"
 #include "BartonCommissionableDataProvider.hpp"
+#include "BartonOperationalKeystore.hpp"
 #include "DeviceInfoProviderImpl.h"
 #include "IcLogger.hpp"
 #include "OTAProviderImpl.h"
@@ -294,7 +295,8 @@ namespace barton
 
         std::shared_ptr<BartonCommissionableDataProvider> commissionableDataProvider;
 
-        std::unique_ptr<chip::PersistentStorageOperationalKeystore> operationalKeystore;
+        std::shared_ptr<BartonOperationalKeystore> operationalKeystore;
+
         std::unique_ptr<chip::Credentials::PersistentStorageOpCertStore> opCertStore;
         chip::Crypto::DefaultSessionKeystore sessionKeystore;
         chip::CommonCaseDeviceServerInitParams serverInitParams;

--- a/core/src/subsystems/matter/services/BartonMatterServiceRegistry.hpp
+++ b/core/src/subsystems/matter/services/BartonMatterServiceRegistry.hpp
@@ -1,0 +1,76 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 7/29/2025.
+//
+
+#pragma once
+
+#include "BartonOperationalKeystore.hpp"
+#include "default/DefaultOperationalKeystore.hpp"
+#include "glib.h"
+
+#include <memory>
+#include <type_traits>
+
+namespace barton
+{
+    class BartonMatterServiceRegistry final
+    {
+    public:
+        static BartonMatterServiceRegistry &Instance()
+        {
+            static BartonMatterServiceRegistry instance;
+            return instance;
+        }
+
+        template<typename T>
+        typename std::enable_if<std::is_base_of<BartonOperationalKeystore, T>::value, bool>::type
+        RegisterBartonOperationalKeystore(std::shared_ptr<T> service)
+        {
+            g_return_val_if_fail(service, false);
+            g_return_val_if_fail(!operationalKeystore, false);
+
+            operationalKeystore = std::static_pointer_cast<BartonOperationalKeystore>(service);
+            return true;
+        }
+
+        std::shared_ptr<BartonOperationalKeystore> GetBartonOperationalKeystore()
+        {
+            if (!operationalKeystore)
+            {
+                std::shared_ptr<DefaultOperationalKeystore> defaultOperationalKeystore =
+                    std::make_shared<DefaultOperationalKeystore>();
+                RegisterBartonOperationalKeystore(defaultOperationalKeystore);
+            }
+            return operationalKeystore;
+        }
+
+    private:
+        BartonMatterServiceRegistry() = default;
+        ~BartonMatterServiceRegistry() = default;
+
+        std::shared_ptr<BartonOperationalKeystore> operationalKeystore;
+    };
+} // namespace barton

--- a/core/src/subsystems/matter/services/BartonOperationalKeystore.hpp
+++ b/core/src/subsystems/matter/services/BartonOperationalKeystore.hpp
@@ -1,0 +1,94 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 7/24/2025.
+//
+
+#pragma once
+
+#include <../PersistentStorageDelegate.h>
+#include <crypto/OperationalKeystore.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+
+namespace barton
+{
+    /**
+     * @brief Abstract interface for operational keystore implementations in Barton.
+     *
+     * This class defines the required interface for operational keystores used by the Barton system.
+     * It extends chip::Crypto::OperationalKeystore and adds an optional initialization method for
+     * persistent storage-backed implementations.
+     *
+     * The primary purpose of this class is to provide a flexible extension point: clients can supply
+     * their own keystore implementation by inheriting from BartonOperationalKeystore. If a client does
+     * not provide a custom implementation, the system will fall back to a default adapter that wraps
+     * PersistentStorageOperationalKeystore.
+     *
+     * All methods are pure virtual, making this a strict interface that enforces implementation of
+     * all required keystore operations in derived classes.
+     */
+    class BartonOperationalKeystore : public chip::Crypto::OperationalKeystore
+    {
+    public:
+        BartonOperationalKeystore() = default;
+        virtual ~BartonOperationalKeystore() = default;
+
+        // Non-copyable
+        BartonOperationalKeystore(BartonOperationalKeystore const &) = delete;
+        void operator=(BartonOperationalKeystore const &) = delete;
+
+        /**
+         * @brief Optionally initialize the keystore with a PersistentStorageDelegate.
+         *
+         * Implement this method if your BartonOperationalKeystore requires access to a PersistentStorageDelegate
+         * (e.g., for persistent storage-backed implementations). If your implementation does not require it,
+         * you may provide an empty implementation.
+         *
+         * @param storageDelegate Pointer to the persistent storage delegate, or nullptr if not needed.
+         * @return CHIP_NO_ERROR on success, or an appropriate CHIP_ERROR code.
+         */
+        virtual CHIP_ERROR Init(PersistentStorageDelegate *storageDelegate) = 0;
+
+        // Required interface methods from OperationalKeystore
+        bool HasPendingOpKeypair() const override = 0;
+        bool HasOpKeypairForFabric(chip::FabricIndex fabricIndex) const override = 0;
+        CHIP_ERROR NewOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                         chip::MutableByteSpan &outCertificateSigningRequest) override = 0;
+        CHIP_ERROR ActivateOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                              const chip::Crypto::P256PublicKey &nocPublicKey) override = 0;
+        CHIP_ERROR CommitOpKeypairForFabric(chip::FabricIndex fabricIndex) override = 0;
+        CHIP_ERROR RemoveOpKeypairForFabric(chip::FabricIndex fabricIndex) override = 0;
+        void RevertPendingKeypair() override = 0;
+        CHIP_ERROR SignWithOpKeypair(chip::FabricIndex fabricIndex,
+                                     const chip::ByteSpan &message,
+                                     chip::Crypto::P256ECDSASignature &outSignature) const override = 0;
+        chip::Crypto::P256Keypair *AllocateEphemeralKeypairForCASE() override = 0;
+        void ReleaseEphemeralKeypair(chip::Crypto::P256Keypair *keypair) override = 0;
+        CHIP_ERROR ExportOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                            chip::Crypto::P256SerializedKeypair &outKeypair) override = 0;
+        CHIP_ERROR MigrateOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                             chip::Crypto::OperationalKeystore &operationalKeystore) const override = 0;
+    };
+} // namespace barton

--- a/core/src/subsystems/matter/services/default/DefaultOperationalKeystore.cpp
+++ b/core/src/subsystems/matter/services/default/DefaultOperationalKeystore.cpp
@@ -1,0 +1,104 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 7/30/2025.
+//
+
+#include "DefaultOperationalKeystore.hpp"
+
+namespace barton
+{
+    CHIP_ERROR DefaultOperationalKeystore::Init(PersistentStorageDelegate *storageDelegate)
+    {
+        return mImplementation.Init(storageDelegate);
+    }
+
+    bool DefaultOperationalKeystore::HasPendingOpKeypair() const
+    {
+        return mImplementation.HasPendingOpKeypair();
+    }
+
+    bool DefaultOperationalKeystore::HasOpKeypairForFabric(const chip::FabricIndex fabricIndex) const
+    {
+        return mImplementation.HasOpKeypairForFabric(fabricIndex);
+    }
+
+    CHIP_ERROR DefaultOperationalKeystore::NewOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                                                 chip::MutableByteSpan &outCertificateSigningRequest)
+    {
+        return mImplementation.NewOpKeypairForFabric(fabricIndex, outCertificateSigningRequest);
+    }
+
+    CHIP_ERROR DefaultOperationalKeystore::ActivateOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                                                      const chip::Crypto::P256PublicKey &nocPublicKey)
+    {
+        return mImplementation.ActivateOpKeypairForFabric(fabricIndex, nocPublicKey);
+    }
+
+    CHIP_ERROR DefaultOperationalKeystore::CommitOpKeypairForFabric(chip::FabricIndex fabricIndex)
+    {
+        return mImplementation.CommitOpKeypairForFabric(fabricIndex);
+    }
+
+    CHIP_ERROR DefaultOperationalKeystore::RemoveOpKeypairForFabric(chip::FabricIndex fabricIndex)
+    {
+        return mImplementation.RemoveOpKeypairForFabric(fabricIndex);
+    }
+
+    void DefaultOperationalKeystore::RevertPendingKeypair()
+    {
+        mImplementation.RevertPendingKeypair();
+    }
+
+    CHIP_ERROR DefaultOperationalKeystore::SignWithOpKeypair(chip::FabricIndex fabricIndex,
+                                                             const chip::ByteSpan &message,
+                                                             chip::Crypto::P256ECDSASignature &outSignature) const
+    {
+        return mImplementation.SignWithOpKeypair(fabricIndex, message, outSignature);
+    }
+
+    chip::Crypto::P256Keypair *DefaultOperationalKeystore::AllocateEphemeralKeypairForCASE()
+    {
+        return mImplementation.AllocateEphemeralKeypairForCASE();
+    }
+
+    void DefaultOperationalKeystore::ReleaseEphemeralKeypair(chip::Crypto::P256Keypair *keypair)
+    {
+        mImplementation.ReleaseEphemeralKeypair(keypair);
+    }
+
+    CHIP_ERROR DefaultOperationalKeystore::ExportOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                                                    chip::Crypto::P256SerializedKeypair &outKeypair)
+    {
+        return mImplementation.ExportOpKeypairForFabric(fabricIndex, outKeypair);
+    }
+
+    CHIP_ERROR
+    DefaultOperationalKeystore::MigrateOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                                          chip::Crypto::OperationalKeystore &operationalKeystore) const
+    {
+        return mImplementation.MigrateOpKeypairForFabric(fabricIndex, operationalKeystore);
+    }
+
+} // namespace barton

--- a/core/src/subsystems/matter/services/default/DefaultOperationalKeystore.hpp
+++ b/core/src/subsystems/matter/services/default/DefaultOperationalKeystore.hpp
@@ -1,0 +1,82 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 7/29/2025.
+//
+
+#pragma once
+
+#include "../PersistentStorageDelegate.h"
+#include "BartonOperationalKeystore.hpp"
+#include "crypto/PersistentStorageOperationalKeystore.h"
+#include "lib/core/CHIPError.h"
+
+namespace barton
+{
+    /**
+     * @brief Adapter for PersistentStorageOperationalKeystore using composition.
+     *
+     * The BartonOperationalKeystore abstraction allows clients to supply their own
+     * OperationalKeystore implementation. If a client does not provide one, the system
+     * falls back to using PersistentStorageOperationalKeystore, which itself inherits
+     * from OperationalKeystore.
+     *
+     * Rather than introducing a complex inheritance hierarchy to support this fallback,
+     * we use the adapter pattern: DefaultOperationalKeystore composes a
+     * PersistentStorageOperationalKeystore and forwards all required operations to it.
+     * This approach simplifies our design, making it easy to swap between
+     * different keystore implementations without creating a mess of complicated
+     * inheritance relationships.
+     */
+    class DefaultOperationalKeystore : public BartonOperationalKeystore
+    {
+    private:
+        chip::PersistentStorageOperationalKeystore mImplementation;
+
+    public:
+        DefaultOperationalKeystore() = default;
+        ~DefaultOperationalKeystore() override = default;
+
+        // Required methods from BartonOperationalKeystore
+        CHIP_ERROR Init(PersistentStorageDelegate *storageDelegate) override;
+        bool HasPendingOpKeypair() const override;
+        bool HasOpKeypairForFabric(chip::FabricIndex fabricIndex) const override;
+        CHIP_ERROR NewOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                         chip::MutableByteSpan &outCertificateSigningRequest) override;
+        CHIP_ERROR ActivateOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                              const chip::Crypto::P256PublicKey &nocPublicKey) override;
+        CHIP_ERROR CommitOpKeypairForFabric(chip::FabricIndex fabricIndex) override;
+        CHIP_ERROR RemoveOpKeypairForFabric(chip::FabricIndex fabricIndex) override;
+        void RevertPendingKeypair() override;
+        CHIP_ERROR SignWithOpKeypair(chip::FabricIndex fabricIndex,
+                                     const chip::ByteSpan &message,
+                                     chip::Crypto::P256ECDSASignature &outSignature) const override;
+        chip::Crypto::P256Keypair *AllocateEphemeralKeypairForCASE() override;
+        void ReleaseEphemeralKeypair(chip::Crypto::P256Keypair *keypair) override;
+        CHIP_ERROR ExportOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                            chip::Crypto::P256SerializedKeypair &outKeypair) override;
+        CHIP_ERROR MigrateOpKeypairForFabric(chip::FabricIndex fabricIndex,
+                                             chip::Crypto::OperationalKeystore &operationalKeystore) const override;
+    };
+} // namespace barton

--- a/core/test/src/subsystems/matter/BartonOperationalKeystoreTest.cpp
+++ b/core/test/src/subsystems/matter/BartonOperationalKeystoreTest.cpp
@@ -1,0 +1,222 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 8/5/2025.
+//
+
+#include "../PersistentStorageDelegate.h"
+#include "BartonMatterServiceRegistry.hpp"
+#include "DefaultOperationalKeystore.hpp"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace barton
+{
+    class MockPersistentStorageDelegate : public barton::PersistentStorageDelegate
+    {
+    public:
+        MOCK_METHOD(CHIP_ERROR, SyncGetKeyValue, (const char *key, void *value, uint16_t &size), (override));
+        MOCK_METHOD(CHIP_ERROR, SyncSetKeyValue, (const char *key, const void *value, uint16_t size), (override));
+        MOCK_METHOD(CHIP_ERROR, SyncDeleteKeyValue, (const char *key), (override));
+    };
+
+    class MockBartonOperationalKeystore : public barton::BartonOperationalKeystore
+    {
+    public:
+        MOCK_METHOD(CHIP_ERROR, Init, (barton::PersistentStorageDelegate * storageDelegate), (override));
+        MOCK_METHOD(bool, HasPendingOpKeypair, (), (const, override));
+        MOCK_METHOD(bool, HasOpKeypairForFabric, (chip::FabricIndex fabricIndex), (const, override));
+        MOCK_METHOD(CHIP_ERROR,
+                    NewOpKeypairForFabric,
+                    (chip::FabricIndex fabricIndex, chip::MutableByteSpan &outCsr),
+                    (override));
+        MOCK_METHOD(CHIP_ERROR,
+                    ActivateOpKeypairForFabric,
+                    (chip::FabricIndex fabricIndex, const chip::Crypto::P256PublicKey &nocPublicKey),
+                    (override));
+        MOCK_METHOD(CHIP_ERROR, CommitOpKeypairForFabric, (chip::FabricIndex fabricIndex), (override));
+        MOCK_METHOD(CHIP_ERROR, RemoveOpKeypairForFabric, (chip::FabricIndex fabricIndex), (override));
+        MOCK_METHOD(void, RevertPendingKeypair, (), (override));
+        MOCK_METHOD(CHIP_ERROR,
+                    SignWithOpKeypair,
+                    (chip::FabricIndex fabricIndex,
+                     const chip::ByteSpan &message,
+                     chip::Crypto::P256ECDSASignature &outSignature),
+                    (const, override));
+        MOCK_METHOD(chip::Crypto::P256Keypair *, AllocateEphemeralKeypairForCASE, (), (override));
+        MOCK_METHOD(void, ReleaseEphemeralKeypair, (chip::Crypto::P256Keypair * keypair), (override));
+        MOCK_METHOD(CHIP_ERROR,
+                    ExportOpKeypairForFabric,
+                    (chip::FabricIndex fabricIndex, chip::Crypto::P256SerializedKeypair &outKeypair),
+                    (override));
+        MOCK_METHOD(CHIP_ERROR,
+                    MigrateOpKeypairForFabric,
+                    (chip::FabricIndex fabricIndex, chip::Crypto::OperationalKeystore &operationalKeystore),
+                    (const, override));
+    };
+
+    class BartonOperationalKeystoreTest : public ::testing::Test
+    {
+    public:
+        DefaultOperationalKeystore *operationalKeystore;
+
+    protected:
+        void SetUp() override
+        {
+            // Necessary to facilitate some underlying implementation operations
+            chip::Platform::MemoryInit();
+            operationalKeystore = new DefaultOperationalKeystore();
+        }
+
+        void TearDown() override
+        {
+            delete operationalKeystore;
+            operationalKeystore = nullptr;
+            chip::Platform::MemoryShutdown();
+        }
+
+        MockPersistentStorageDelegate mockStorage;
+    };
+
+    // Test that DefaultOperationalKeystore correctly forwards method calls to the underlying implementation.
+    // This test doesn't validate the correctness of the underlying PersistentStorageOperationalKeystore,
+    // but rather ensures our adapter pattern is functioning as expected by verifying that:
+    // 1. Method calls on the adapter are properly forwarded to the underlying implementation
+    // 2. Return values from the implementation are correctly passed back through the adapter
+    // 3. The adapter doesn't modify or interfere with the implementation's behavior
+    TEST_F(BartonOperationalKeystoreTest, DefaultKeystoreMethodForwarding)
+    {
+        // Set up test values
+        chip::FabricIndex testFabricIndex = 1;
+        uint8_t csrData[128] = {0};
+        chip::MutableByteSpan csrSpan(csrData);
+        chip::Crypto::P256PublicKey nocPublicKey;
+        chip::Crypto::P256SerializedKeypair serializedKeypair;
+        chip::ByteSpan message(csrData, 32); // Reuse buffer for message data
+        chip::Crypto::P256ECDSASignature signature;
+
+        // Set up default mock behaviors
+        ON_CALL(mockStorage, SyncGetKeyValue(testing::_, testing::_, testing::_))
+            .WillByDefault(testing::Return(CHIP_NO_ERROR));
+        ON_CALL(mockStorage, SyncDeleteKeyValue(testing::_)).WillByDefault(testing::Return(CHIP_NO_ERROR));
+        ON_CALL(mockStorage, SyncSetKeyValue(testing::_, testing::_, testing::_))
+            .WillByDefault(testing::Return(CHIP_NO_ERROR));
+
+        // Test Init
+        CHIP_ERROR result = operationalKeystore->Init(&mockStorage);
+        EXPECT_EQ(result, CHIP_NO_ERROR);
+
+        // Test HasPendingOpKeypair
+        // No explicit expectations needed, internal state check
+        EXPECT_FALSE(operationalKeystore->HasPendingOpKeypair());
+
+        // Test HasOpKeypairForFabric
+        EXPECT_CALL(mockStorage, SyncGetKeyValue(testing::_, testing::_, testing::_))
+            .WillOnce(testing::Return(CHIP_NO_ERROR));
+        EXPECT_TRUE(operationalKeystore->HasOpKeypairForFabric(testFabricIndex));
+
+        // Test NewOpKeypairForFabric
+        // Complex method, expect it to fail due to keypair initialization issues
+        result = operationalKeystore->NewOpKeypairForFabric(testFabricIndex, csrSpan);
+        EXPECT_NE(result, CHIP_NO_ERROR);
+
+        // Test ActivateOpKeypairForFabric
+        // Should fail since we don't have a valid keypair
+        result = operationalKeystore->ActivateOpKeypairForFabric(testFabricIndex, nocPublicKey);
+        EXPECT_NE(result, CHIP_NO_ERROR);
+
+        // Test CommitOpKeypairForFabric
+        // Should fail since we don't have an active keypair
+        result = operationalKeystore->CommitOpKeypairForFabric(testFabricIndex);
+        EXPECT_NE(result, CHIP_NO_ERROR);
+
+        // Test RemoveOpKeypairForFabric
+        EXPECT_CALL(mockStorage, SyncDeleteKeyValue(testing::_)).WillOnce(testing::Return(CHIP_NO_ERROR));
+        result = operationalKeystore->RemoveOpKeypairForFabric(testFabricIndex);
+        EXPECT_EQ(result, CHIP_NO_ERROR);
+
+        // Test RevertPendingKeypair
+        // Void method, just make sure it doesn't crash
+        operationalKeystore->RevertPendingKeypair();
+
+        // Test SignWithOpKeypair
+        EXPECT_CALL(mockStorage, SyncGetKeyValue(testing::_, testing::_, testing::_))
+            .WillOnce(testing::Return(CHIP_NO_ERROR));
+        result = operationalKeystore->SignWithOpKeypair(testFabricIndex, message, signature);
+        EXPECT_NE(result, CHIP_NO_ERROR);
+
+        // Test AllocateEphemeralKeypairForCASE
+        auto keypair = operationalKeystore->AllocateEphemeralKeypairForCASE();
+        EXPECT_NE(keypair, nullptr);
+
+        // Test ReleaseEphemeralKeypair
+        // Void method, just make sure it doesn't crash
+        operationalKeystore->ReleaseEphemeralKeypair(keypair);
+
+        // Test ExportOpKeypairForFabric
+        EXPECT_CALL(mockStorage, SyncGetKeyValue(testing::_, testing::_, testing::_))
+            .WillOnce(testing::Return(CHIP_ERROR_KEY_NOT_FOUND));
+        result = operationalKeystore->ExportOpKeypairForFabric(testFabricIndex, serializedKeypair);
+        EXPECT_NE(result, CHIP_NO_ERROR);
+
+        // Test MigrateOpKeypairForFabric
+        EXPECT_CALL(mockStorage, SyncGetKeyValue(testing::_, testing::_, testing::_))
+            .WillOnce(testing::Return(CHIP_ERROR_KEY_NOT_FOUND));
+        chip::PersistentStorageOperationalKeystore otherKeystore;
+        result = operationalKeystore->MigrateOpKeypairForFabric(testFabricIndex, otherKeystore);
+        EXPECT_NE(result, CHIP_NO_ERROR);
+    }
+
+    // Test that the service registry creates a DefaultOperationalKeystore when none is provided
+    TEST_F(BartonOperationalKeystoreTest, ServiceRegistryUsesDefaultImplementation)
+    {
+        // Get the keystore from the service registry
+        auto keystore = barton::BartonMatterServiceRegistry::Instance().GetBartonOperationalKeystore();
+
+        // Verify it's a DefaultOperationalKeystore
+        EXPECT_NE(dynamic_cast<barton::DefaultOperationalKeystore *>(keystore.get()), nullptr);
+    }
+
+    // Test that a custom implementation can be registered and used
+    TEST_F(BartonOperationalKeystoreTest, RegisterAndUseCustomImplementation)
+    {
+        auto customKeystore = std::make_shared<MockBartonOperationalKeystore>();
+
+        // Register the custom implementation with the registry
+        bool registered =
+            barton::BartonMatterServiceRegistry::Instance().RegisterBartonOperationalKeystore(customKeystore);
+        EXPECT_TRUE(registered);
+
+        // Get it back from the registry and use it
+        auto keystore = barton::BartonMatterServiceRegistry::Instance().GetBartonOperationalKeystore();
+        EXPECT_EQ(keystore.get(), customKeystore.get()); // Should be exactly our implementation
+
+        // Verify the expectations by using the keystore
+        chip::FabricIndex testFabricIndex = 1;
+        EXPECT_CALL(*customKeystore, HasPendingOpKeypair()).WillOnce(testing::Return(true));
+        EXPECT_CALL(*customKeystore, HasOpKeypairForFabric(testing::_)).WillOnce(testing::Return(true));
+        EXPECT_TRUE(keystore->HasPendingOpKeypair());
+        EXPECT_TRUE(keystore->HasOpKeypairForFabric(testFabricIndex));
+    }
+} // namespace barton

--- a/core/test/src/subsystems/matter/CMakeLists.txt
+++ b/core/test/src/subsystems/matter/CMakeLists.txt
@@ -33,6 +33,8 @@ list(APPEND TEST_SRC ${PROJECT_SOURCE_DIR}/core/src/subsystems/matter/ReadPrepar
                      ${PROJECT_SOURCE_DIR}/core/src/subsystems/matter/providers/BartonCommissionableDataProvider.cpp
                      ${PROJECT_SOURCE_DIR}/core/src/subsystems/matter/providers/default/DefaultCommissionableDataProvider.cpp
                      ${PROJECT_SOURCE_DIR}/core/src/subsystems/matter/providers/BartonDeviceInstanceInfoProvider.cpp
+                     ${PROJECT_SOURCE_DIR}/core/src/subsystems/matter/services/default/DefaultOperationalKeystore.cpp
+                     ${PROJECT_SOURCE_DIR}/core/src/subsystems/matter/PersistentStorageDelegate.cpp
                      ${PROJECT_SOURCE_DIR}/api/c/src/provider/barton-core-property-provider.c
                      ${PROJECT_SOURCE_DIR}/api/c/src/provider/barton-core-default-property-provider.c
                      ${PROJECT_SOURCE_DIR}/core/src/deviceServiceConfiguration.c)


### PR DESCRIPTION
Stacked PRs:
 * __->__#55
 * #54


--- --- ---

### feat(matter): add BartonOperationalKeystore


Implement mechanism allowing clients to provide custom operational keystore
implementations. The system will use a default implementation when none is
provided by the client.

Key components:
- BartonOperationalKeystore interface for client implementations
- Default adapter pattern implementation wrapping PersistentStorageOperationalKeystore
- Service registry with lazy initialization of default implementation
- Tests validating expected behavior

This approach provides better flexibility for clients that need custom
keystore implementations while maintaining compatibility with the Matter
framework.

Refs: BARTON-265