### PR TITLE
build: Support BCORE_LINK_LIBRARIES

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -237,6 +237,10 @@ bcore_string_option(NAME BCORE_MATTER_BLE_CONTROLLER_DEVICE_NAME
                     DESCRIPTION "Name of the Matter BLE controller device."
                     VALUE "Matter-Controller")
 
+bcore_string_option(NAME BCORE_LINK_LIBRARIES
+                  DEFINITION BARTON_CONFIG_LINK_LIBRARIES
+                  DESCRIPTION "List of additional libraries to link against when building the Barton Device Service. This allows custom client code to depend on external libraries as well.")
+
 message(STATUS "- - - - - - - - - - - - - - - - ")
 
 message(STATUS "- - - - - - - - - - - - - - - - ")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -177,7 +177,7 @@ list(APPEND XTRA_INCLUDES ${CURL_INCLUDE_DIRS})
 set(bCoreLinkLibraries bCoreConfig xhLog xhTypes xhTime xhUtil
         xhConcurrent xhConfig xhUrlHelper xhXmlHelper xhJsonHelper
         xhDeviceHelper xhDeviceDescriptors xhXmlHelper
-        xhCrypto ${XTRA_LIBS} cjson uuid curl xml2 z m)
+        xhCrypto ${XTRA_LIBS} cjson uuid curl xml2 z m ${BCORE_LINK_LIBRARIES})
 
 if (BCORE_SUPPORT_SOFTWARE_WATCHDOG)
     set(bCoreLinkLibraries ${bCoreLinkLibraries} xhSoftwareWatchdog)


### PR DESCRIPTION
This commit adds a build mechanism for supplying custom libraries to barton's targets involving linking. This facillitates custom code (such as matter plugin code) being dependent on libraries not known to barton.