### PR TITLE
build: Set SO Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,28 @@ cmake_minimum_required(VERSION 3.16.5)
 #TODO: project version (snag from git tag)
 project(barton-core)
 
+execute_process(
+                COMMAND git describe --tags --match [0-9]*.[0-9]*.[0-9]*
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                OUTPUT_VARIABLE BARTON_CORE_VERSION
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                )
+
+message(STATUS "Barton Version: ${BARTON_CORE_VERSION}")
+string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" BARTON_CORE_SO_VERSION ${BARTON_CORE_VERSION})
+message(STATUS "Barton SO Version: ${BARTON_CORE_SO_VERSION}")
+string(REGEX MATCHALL "[0-9]+" BARTON_CORE_VERSION_LIST ${BARTON_CORE_SO_VERSION})
+
+list(GET BARTON_CORE_VERSION_LIST 0 BARTON_CORE_MAJOR_VERSION)
+list(GET BARTON_CORE_VERSION_LIST 1 BARTON_CORE_MINOR_VERSION)
+list(GET BARTON_CORE_VERSION_LIST 2 BARTON_CORE_PATCH_VERSION)
+
+# This is what you may also call the platform version. The focue is API/ABI compatibility.
+# As such, the minor version rarely changes. This is analog to GLib/GTK/GIR namespace
+# version schemeing where a semver of 4.24.3 has api version 4.0
+set(BARTON_CORE_API_VERSION "${BARTON_CORE_MAJOR_VERSION}.0")
+message(STATUS "Barton API Version: ${BARTON_CORE_API_VERSION}")
+
 include(CTest)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -218,6 +218,8 @@ target_include_directories(BartonCore PRIVATE
                             PUBLIC
                             ${BARTON_PUBLIC_INCLUDES}
                             )
+
+set_target_properties(BartonCore PROPERTIES VERSION ${BARTON_CORE_SO_VERSION} SOVERSION ${BARTON_CORE_MAJOR_VERSION})
 install(TARGETS BartonCore DESTINATION lib)
 
 # If specified, generate GIR and typelib. Clients need to ensure that the GIR and/or typelib
@@ -238,7 +240,7 @@ if (BCORE_GEN_GIR)
     endif()
 
     set(NAMESPACE BCore)
-    set(NAMESPACE_VERSION 1.0)
+    set(NAMESPACE_VERSION ${BARTON_CORE_API_VERSION})
     set(GIR_OUTPUT_NAME ${NAMESPACE}-${NAMESPACE_VERSION}.gir)
     set(GIR_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${GIR_OUTPUT_NAME})
     set(TYPELIB_OUTPUT_NAME ${NAMESPACE}-${NAMESPACE_VERSION}.typelib)


### PR DESCRIPTION
This commit adds support for setting the library version and SO version of libBartonCore. It also defines a "barton API version" that is an analog for namespace/platform version used in gir generation.