### PR TITLE
build: Disable BCORE_GEN_GIR

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -138,8 +138,7 @@ bcore_option(NAME BCORE_PHILIPS_HUE
            DESCRIPTION "Enable Philips Hue support")
 bcore_option(NAME BCORE_GEN_GIR
            DEFINITION BARTON_CONFIG_GEN_GIR
-           DESCRIPTION "Enable generating GIR and typelib information"
-           ENABLE)
+           DESCRIPTION "Enable generating GIR and typelib information")
 bcore_option(NAME BCORE_GENERATE_DEFAULT_LABELS
            DEFINITION BARTON_CONFIG_GENERATE_DEFAULT_LABELS
            DESCRIPTION "Enable generating default labels for devices that support the label resource")

--- a/config/cmake/platforms/dev/linux.cmake
+++ b/config/cmake/platforms/dev/linux.cmake
@@ -32,6 +32,8 @@ set(BCORE_BUILD_WITH_ASAN ON CACHE BOOL "Build with ASAN")
 
 set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/matter-install" CACHE PATH "Path to Matter installation")
 
+set(BCORE_GEN_GIR ON CACHE BOOL "Gir generation")
+
 # Matter settings
 include(${CMAKE_SOURCE_DIR}/config/cmake/modules/BCoreMatterHelper.cmake)
 


### PR DESCRIPTION
BCORE_GEN_GIR is only needed for introspection, which is not a feature anyone is using except us to run integration tests. For now, disable it by default so it does not cause any unnecessary dependency requirements.

Refs: BARTON-271