### PR TITLE
feat: implement software watchdog delegate interface

### DIFF
--- a/api/c/public/private/softwareWatchdogDelegate/softwareWatchdogDelegate.h
+++ b/api/c/public/private/softwareWatchdogDelegate/softwareWatchdogDelegate.h
@@ -1,0 +1,125 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 8/22/2025.
+//
+
+#pragma once
+
+#include <stdbool.h>
+
+/**
+ * @brief Base software watchdog delegate interface for Barton Core subsystems.
+ *
+ * This struct provides a standardized interface for subsystems to interact with
+ * external software watchdog systems.
+ *
+ * The delegate pattern allows subsystems to:
+ * - Initialize and configure their watchdog monitoring
+ * - Periodically "tickle" the watchdog to indicate healthy operation
+ * - Check if recovery operations are in progress
+ * - Cleanly shutdown watchdog monitoring
+ *
+ * @note All function pointers may be NULL if the functionality is not needed
+ *       or not available. Always check for NULL before calling.
+ */
+typedef struct BartonSoftwareWatchdogDelegate
+{
+    /**
+     * @brief Initialize the software watchdog system.
+     *
+     * This function is called once during subsystem initialization to set up
+     * watchdog monitoring. It should configure any necessary watchdog entities,
+     * timers, or monitoring threads.
+     *
+     * @note May be NULL if no initialization is required
+     */
+    void (*initializeWatchdog)(void);
+
+    /**
+     * @brief Shutdown the software watchdog system.
+     *
+     * This function is called during subsystem shutdown to cleanly disable
+     * watchdog monitoring, stop any background threads, and free resources.
+     * Should ensure no false watchdog triggers occur during shutdown.
+     *
+     * @note May be NULL if no shutdown cleanup is required
+     */
+    void (*shutdownWatchdog)(void);
+
+    /**
+     * @brief Tickle/pet the watchdog to indicate healthy operation.
+     *
+     * @note May be NULL if not needed
+     */
+    void (*tickleWatchdog)(void);
+
+    /**
+     * @brief Check if a watchdog recovery action is currently in progress.
+     *
+     * This function allows subsystems to query whether the watchdog system
+     * is currently performing recovery operations (e.g., restarting services).
+     *
+     * @return true if recovery is in progress, false otherwise
+     * @note May be NULL if recovery status checking is not supported
+     */
+    bool (*getActionInProgress)(void);
+
+    /**
+     * @brief Name of the process being monitored by this watchdog.
+     *
+     * This string identifies the specific process or subsystem that this
+     * watchdog delegate is responsible for monitoring. Used for logging,
+     * debugging, and recovery coordination.
+     *
+     * @note REQUIRED - Must not be NULL
+     */
+    const char *processName;
+
+} BartonSoftwareWatchdogDelegate;
+
+/**
+ * @brief Create a new BartonSoftwareWatchdogDelegate instance.
+ *
+ * Allocates memory for a new watchdog delegate and initializes all function
+ * pointers to NULL. The caller is responsible for setting appropriate function
+ * pointers after creation.
+ *
+ * @param name The name of the process being monitored
+ * @return Pointer to newly allocated delegate, or NULL on error
+ * @note Caller must call destroyBartonSoftwareWatchdogDelegate() to free memory
+ */
+BartonSoftwareWatchdogDelegate *createBartonSoftwareWatchdogDelegate(const char *name);
+
+/**
+ * @brief Destroy a BartonSoftwareWatchdogDelegate instance.
+ *
+ * Frees the memory allocated for the watchdog delegate. Does not call any
+ * of the function pointers (like shutdownWatchdog) - the caller should
+ * perform any necessary cleanup before calling this function.
+ *
+ * @param delegate Pointer to the delegate to destroy, may be NULL (no-op)
+ * @note After calling this function, the delegate pointer is invalid
+ */
+void destroyBartonSoftwareWatchdogDelegate(BartonSoftwareWatchdogDelegate *delegate);

--- a/api/c/public/private/subsystems/zigbee/zigbeeSubsystem.h
+++ b/api/c/public/private/subsystems/zigbee/zigbeeSubsystem.h
@@ -28,6 +28,7 @@
 #define FLEXCORE_ZIGBEESUBSYSTEM_H
 
 #include "device-driver/device-driver.h"
+#include "private/subsystems/zigbee/zigbeeSubsystemWatchdogDelegate.h"
 #include "zigbeeAttributeTypes.h"
 #include <cjson/cJSON.h>
 #include <deviceDescriptor.h>
@@ -35,13 +36,24 @@
 #include <stdbool.h>
 #include <zhal/zhal.h>
 
-#define ZIGBEE_SUBSYSTEM_NAME             "zigbee"
-#define NETWORK_BLOB_PROPERTY_NAME        "ZIGBEE_NETWORK_CONFIG_DATA"
+#define ZIGBEE_CORE_PROCESS_NAME               "ZigbeeCore"
+#define ZIGBEE_SUBSYSTEM_NAME                  "zigbee"
+#define NETWORK_BLOB_PROPERTY_NAME             "ZIGBEE_NETWORK_CONFIG_DATA"
+
+#define ZIGBEE_INCREMENT_COUNTERS_ON_NEXT_INIT "ZIGBEE_INCREMENT_COUNTERS_ON_NEXT_INIT"
+
+// The amount we should increment the counters after things like RMA.  The values here are what we have historically
+// used
+#define NONCE_COUNTER_INCREMENT_AMOUNT         0x1000
+#define FRAME_COUNTER_INCREMENT_AMOUNT         0x1000
 
 /* 27 min */
-#define ZIGBEE_DEFAULT_CHECKIN_INTERVAL_S 27 * 60
+#define ZIGBEE_DEFAULT_CHECKIN_INTERVAL_S      27 * 60
 
-#define FAST_COMM_FAIL_PROP               "zigbee.testing.fastCommFail.flag"
+#define ZIGBEE_CORE_MAX_NETWORK_INIT_RETRIES   3
+
+#define FAST_COMM_FAIL_PROP                    "zigbee.testing.fastCommFail.flag"
+#define ZIGBEE_PROPS_PREFIX                    "cpe.zigbee."
 
 typedef enum
 {
@@ -383,6 +395,29 @@ uint64_t getLocalEui64(void);
  * @return 0 on success
  */
 int zigbeeSubsystemSetAddresses(void);
+
+/**
+ * Set the software watchdog delegate for zigbee subsystem operations.
+ *
+ * IMPORTANT: This must be called BEFORE zigbeeSubsystemInitialize().
+ * Once the subsystem is started, the delegate cannot be changed.
+ *
+ * @param delegate The watchdog delegate implementation, or NULL to disable
+ */
+void zigbeeSubsystemSetWatchdogDelegate(ZigbeeSoftwareWatchdogDelegate *delegate);
+
+/**
+ * Check if the Zigbee network has been successfully initialized.
+ *
+ * @return true if the network is fully initialized and ready for operation,
+ *         false if initialization is still in progress, failed, or not started
+ */
+bool zigbeeSubsystemIsNetworkInitialized(void);
+
+/**
+ * Mark the Zigbee subsystem as ready and operational.
+ */
+void zigbeeSubsystemSetReady(void);
 
 /*
  * Remove a single zigbee device address from those allowed on our network.

--- a/api/c/public/private/subsystems/zigbee/zigbeeSubsystemWatchdogDelegate.h
+++ b/api/c/public/private/subsystems/zigbee/zigbeeSubsystemWatchdogDelegate.h
@@ -1,0 +1,141 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 8/20/2025.
+//
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "private/softwareWatchdogDelegate/softwareWatchdogDelegate.h"
+
+typedef enum
+{
+    ZIGBEE_CORE_RECOVERY_ENITITY_HEARTBEAT,
+    ZIGBEE_CORE_RECOVERY_ENITITY_COMM_FAIL,
+    ZIGBEE_CORE_RECOVERY_ENITITY_NETWORK_BUSY
+} ZigbeeCoreRecoveryEntity;
+
+extern const char *ZigbeeCoreRecoveryEntityLabels[];
+
+extern const char *zigbeeCoreRecoveryReasonLabels[];
+
+// Set a default for watchdog run interval, could make this configurable later
+#define ZIGBEE_CORE_HEARTBEAT_PET_FREQUENCY_SECS 60
+
+/**
+ * @brief Zigbee-specific software watchdog delegate interface.
+ *
+ * This structure extends the base BartonSoftwareWatchdogDelegate with Zigbee-specific
+ * watchdog functionality. It provides specialized operations for monitoring and
+ * recovering ZigbeeCore processes, handling communication failures, and coordinating
+ * recovery actions specific to Zigbee network operations.
+ */
+typedef struct ZigbeeSoftwareWatchdogDelegate
+{
+    /**
+     * @brief Base watchdog delegate providing core functionality.
+     *
+     * Contains the fundamental watchdog operations (initialize, shutdown, tickle, etc.)
+     * that are common across all subsystems. The Zigbee delegate composes this base
+     * delegate to inherit standard watchdog behavior.
+     */
+    BartonSoftwareWatchdogDelegate *baseDelegate;
+
+    /**
+     * @brief Update the status of a specific Zigbee watchdog entity.
+     *
+     * This function allows the Zigbee subsystem to report the health status of
+     * various monitored entities (heartbeat, network busy, communication failure).
+     * The watchdog system can use this information to determine if recovery
+     * actions are needed.
+     *
+     * @param ZigbeeCoreRecoveryEntity The specific Zigbee entity being reported on
+     * @param status true if the entity is healthy, false if it's in a failure state
+     * @return true if the status update was processed successfully, false on error
+     * @note May be NULL if status reporting is not supported
+     */
+    bool (*updateWatchdogStatus)(ZigbeeCoreRecoveryEntity watchdogEntity, bool status);
+
+    /**
+     * @brief Immediately trigger service recovery with detailed trouble information.
+     *
+     * This function provides a mechanism to request immediate recovery of a service
+     * while also reporting specific trouble codes and descriptions. This is typically
+     * used when the Zigbee subsystem detects critical failures that require
+     * immediate intervention rather than waiting for normal watchdog timeouts.
+     *
+     * @param serviceName Name of the service requiring recovery (e.g., "ZigbeeCore")
+     * @param entityName Name of the specific entity that failed (e.g., "heartbeat")
+     * @param troubleString Human-readable description of the problem
+     * @param troubleCode Numeric trouble code for categorization and tracking
+     * @return true if the recovery request was accepted, false on error
+     * @note May be NULL if immediate recovery is not supported
+     */
+    bool (*immediateRecoveryServiceWithTrouble)(const char *serviceName,
+                                                const char *entityName,
+                                                const char *troubleString,
+                                                int troubleCode);
+
+    /**
+     * @brief Signal a monitoring thread for a specific Zigbee watchdog entity.
+     *
+     * This function allows the subsystem to wake up or signal monitoring threads
+     * that are responsible for specific Zigbee entities. This can be used to
+     * trigger immediate checks, wake threads from timed waits, or coordinate
+     * monitoring activities across different watchdog entities.
+     *
+     * @param entity The specific Zigbee watchdog entity whose thread should be signaled
+     * @note May be NULL if thread signaling is not supported
+     */
+    void (*signalThread)(ZigbeeCoreRecoveryEntity entity);
+
+} ZigbeeSoftwareWatchdogDelegate;
+
+/**
+ * @brief Create a new ZigbeeSoftwareWatchdogDelegate instance.
+ *
+ * Allocates memory for a new Zigbee watchdog delegate and initializes it with
+ * a base BartonSoftwareWatchdogDelegate. All Zigbee-specific function pointers
+ * are initialized to NULL and must be set by the caller after creation.
+ *
+ * @return Pointer to newly allocated Zigbee delegate, or NULL on allocation failure
+ * @note Caller must call destroyZigbeeSoftwareWatchdogDelegate() to free memory
+ */
+ZigbeeSoftwareWatchdogDelegate *createZigbeeSoftwareWatchdogDelegate(void);
+
+/**
+ * @brief Destroy a ZigbeeSoftwareWatchdogDelegate instance.
+ *
+ * Frees the memory allocated for the Zigbee watchdog delegate and its composed
+ * base delegate.
+ *
+ * @param delegate Pointer to the Zigbee delegate to destroy, may be NULL (no-op)
+ * @note Does not call any function pointers - caller should perform necessary
+ *       cleanup (like calling shutdownWatchdog) before destruction
+ * @note After calling this function, the delegate pointer is invalid
+ */
+void destroyZigbeeSoftwareWatchdogDelegate(ZigbeeSoftwareWatchdogDelegate *delegate);

--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -183,9 +183,6 @@ bcore_option(NAME BCORE_M1LTE
 bcore_option(NAME BCORE_SETUP_WIZARD
            DEFINITION BARTON_CONFIG_SETUP_WIZARD
            DESCRIPTION "Support for behavioral changes if there is an \"activation period\"")
-bcore_option(NAME BCORE_SUPPORT_SOFTWARE_WATCHDOG
-           DEFINITION BARTON_CONFIG_SUPPORT_SOFTWARE_WATCHDOG
-           DESCRIPTION "Support for zigbee watchdog feature using the software watchdog library.")
 bcore_int_option(NAME BCORE_SOFTWARE_WATCHDOG_TROUBLE_CODE_ZIGBEE_CORE
               DEFINITION BARTON_CONFIG_SOFTWARE_TROUBLE_CODE_ZIGBEE_CORE_WATCHDOG
               DESCRIPTION "The trouble code to use when reporting a zigbee core failure to the software watchdog library."

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -46,7 +46,8 @@ file(GLOB eventSrc "src/event/*.c")
 file(GLOB dbaseSrc "src/database/*.c")
 file(GLOB deviceSrc "src/device/*.c")
 file(GLOB serialSrc "src/serial/*.c")
-set(SOURCES ${mainSrc} ${eventSrc} ${dbaseSrc} ${deviceSrc} ${serialSrc})
+file(GLOB softwareWatchdogSrc "src/softwareWatchdogDelegate/*.c")
+set(SOURCES ${mainSrc} ${eventSrc} ${dbaseSrc} ${deviceSrc} ${serialSrc} ${softwareWatchdogSrc})
 
 # philips lights (if option set)
 if (BCORE_PHILIPS_HUE)
@@ -178,10 +179,6 @@ set(bCoreLinkLibraries bCoreConfig xhLog xhTypes xhTime xhUtil
         xhConcurrent xhConfig xhUrlHelper xhXmlHelper xhJsonHelper
         xhDeviceHelper xhDeviceDescriptors xhXmlHelper
         xhCrypto ${XTRA_LIBS} cjson uuid curl xml2 z m ${BCORE_LINK_LIBRARIES})
-
-if (BCORE_SUPPORT_SOFTWARE_WATCHDOG)
-    set(bCoreLinkLibraries ${bCoreLinkLibraries} xhSoftwareWatchdog)
-endif()
 
 set(BARTON_PRIVATE_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/src
                             ${CMAKE_CURRENT_SOURCE_DIR}/deviceDrivers

--- a/core/src/devicePrivateProperties.h
+++ b/core/src/devicePrivateProperties.h
@@ -36,7 +36,6 @@
 #define DEVICE_FIRMWARE_URL_NODE                              "deviceFirmwareBaseUrl"
 #define CPE_DENYLISTED_DEVICES_PROPERTY_NAME                  "cpe.denylistedDevices"
 #define TOUCHSCREEN_SENSOR_COMMFAIL_TROUBLE_DELAY             "touchscreen.sensor.commFail.troubleDelay"
-#define ZIGBEE_PROPS_PREFIX                                   "cpe.zigbee."
 #define TELEMETRY_PROPS_PREFIX                                "telemetry."
 #define FAST_COMM_FAIL_PROP                                   "zigbee.testing.fastCommFail.flag"
 #define CPE_ZIGBEE_REPORT_DEVICE_INFO_ENABLED                 "cpe.zigbee.reportDeviceInfo.enabled"

--- a/core/src/softwareWatchdogDelegate/softwareWatchdogDelegate.c
+++ b/core/src/softwareWatchdogDelegate/softwareWatchdogDelegate.c
@@ -1,0 +1,66 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 8/22/2025.
+//
+
+#include <stdlib.h>
+
+#include "icLog/logging.h"
+#include "private/softwareWatchdogDelegate/softwareWatchdogDelegate.h"
+
+#define LOG_TAG     "bartonSoftwareWatchdog"
+#define logFmt(fmt) "%s: " fmt, __func__
+
+BartonSoftwareWatchdogDelegate *createBartonSoftwareWatchdogDelegate(const char *name)
+{
+    BartonSoftwareWatchdogDelegate *retVal = NULL;
+
+    if (name)
+    {
+        retVal = calloc(1, sizeof(BartonSoftwareWatchdogDelegate));
+        if (retVal)
+        {
+            retVal->initializeWatchdog = NULL;
+            retVal->shutdownWatchdog = NULL;
+            retVal->tickleWatchdog = NULL;
+            retVal->getActionInProgress = NULL;
+            retVal->processName = name;
+        }
+    }
+    else
+    {
+        icError("Process name is required");
+    }
+
+    return retVal;
+}
+
+void destroyBartonSoftwareWatchdogDelegate(BartonSoftwareWatchdogDelegate *delegate)
+{
+    if (delegate)
+    {
+        free(delegate);
+    }
+}

--- a/core/src/subsystems/zigbee/zigbeeSubsystemWatchdogDelegate.c
+++ b/core/src/subsystems/zigbee/zigbeeSubsystemWatchdogDelegate.c
@@ -1,0 +1,59 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 8/22/2025.
+//
+
+#include <stdlib.h>
+
+#include "private/subsystems/zigbee/zigbeeSubsystem.h"
+#include "private/subsystems/zigbee/zigbeeSubsystemWatchdogDelegate.h"
+
+const char *ZigbeeCoreRecoveryEntityLabels[] = {"heartbeat", "communication failure", "network busy"};
+
+const char *zigbeeCoreRecoveryReasonLabels[] = {"Recovery reason: heartbeat",
+                                                "Recovery reason: communication failure",
+                                                "Recovery reason: network busy"};
+
+ZigbeeSoftwareWatchdogDelegate *createZigbeeSoftwareWatchdogDelegate(void)
+{
+    ZigbeeSoftwareWatchdogDelegate *retVal = calloc(1, sizeof(ZigbeeSoftwareWatchdogDelegate));
+    if (retVal)
+    {
+        retVal->baseDelegate = createBartonSoftwareWatchdogDelegate(ZIGBEE_CORE_PROCESS_NAME);
+        retVal->updateWatchdogStatus = NULL;
+        retVal->immediateRecoveryServiceWithTrouble = NULL;
+        retVal->signalThread = NULL;
+    }
+    return retVal;
+}
+
+void destroyZigbeeSoftwareWatchdogDelegate(ZigbeeSoftwareWatchdogDelegate *delegate)
+{
+    if (delegate)
+    {
+        destroyBartonSoftwareWatchdogDelegate(delegate->baseDelegate);
+        free(delegate);
+    }
+}


### PR DESCRIPTION
Add base BartonSoftwareWatchdogDelegate and Zigbee-specific extension to provide standardized watchdog functionality across subsystems.

- Create BartonSoftwareWatchdogDelegate with core watchdog operations (initialize, shutdown, tickle, getActionInProgress)
- Add ZigbeeSoftwareWatchdogDelegate extending base with Zigbee-specific recovery functions (updateWatchdogStatus, immediateRecoveryService)
- Implement thread-safe set-once pattern for delegate assignment in zigbeeSubsystem
- Add comprehensive documentation for both delegate interfaces

The delegate pattern allows subsystems to integrate with external watchdog systems while maintaining clean separation of concerns and enabling flexible watchdog implementations.

Resolves watchdog integration requirements for Zigbee subsystem.