### PR TITLE
ci: Add cocogitto support to actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,8 @@
 #
 
 name: Release
+permissions:
+  contents: write
 
 on:
     workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+# ------------------------------ tabstop = 4 ----------------------------------
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2025 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# ------------------------------ tabstop = 4 ----------------------------------
+
+#
+# Created by Christian Leithner on 9/2/2025.
+#
+
+name: Release
+
+on:
+    workflow_dispatch:
+
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.RDKCM_DEPLOY_KEY }}
+
+      - name: Semver release
+        id: release
+        uses: cocogitto/cocogitto-action@v3
+        with:
+          release: true
+
+      - name: Generate Changelog
+        run: cog changelog --at ${{ steps.release.outputs.version }} > CHANGELOG.md
+
+      - name: Upload github release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: CHANGELOG.md
+          tag_name: ${{ steps.release.outputs.version }}

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,11 @@
+# Basic settings
+from_latest_tag = true
+ignore_merge_commits = true
+
+# Changelog settings
+[changelog]
+path = "CHANGELOG.md"
+template = "config/cocogitto/templates/remote_extended"
+remote = "github.com"
+owner = "cleithner-comcast"
+repository = "BartonCore_fork"

--- a/cog.toml
+++ b/cog.toml
@@ -7,5 +7,5 @@ ignore_merge_commits = true
 path = "CHANGELOG.md"
 template = "config/cocogitto/templates/remote_extended"
 remote = "github.com"
-owner = "cleithner-comcast"
-repository = "BartonCore_fork"
+owner = "rdkcentral"
+repository = "BartonCore"

--- a/config/cocogitto/templates/remote_extended
+++ b/config/cocogitto/templates/remote_extended
@@ -1,0 +1,84 @@
+{% if version.tag and from.tag -%}
+    ## [{{ version.tag }}]({{repository_url ~ "/compare/" ~ from.tag ~ ".." ~ version.tag}}) - {{ date | date(format="%Y-%m-%d") }}
+{% elif version.tag and from.id -%}
+    ## [{{ version.tag }}]({{repository_url ~ "/compare/" ~ from.id ~ ".." ~ version.tag}}) - {{ date | date(format="%Y-%m-%d") }}
+{% else -%}
+    {% set from = from.id -%}
+    {% set to = version.id -%}
+
+    {% set from_shorthand = from.id | truncate(length=7, end="") -%}
+    {% set to_shorthand = version.id | truncate(length=7, end="") -%}
+
+    ## Unreleased ([{{ from_shorthand ~ ".." ~ to_shorthand }}]({{repository_url ~ "/compare/" ~ from_shorthand ~ ".." ~ to_shorthand}}))
+{% endif -%}
+
+{% set breaking_commits = commits | sort(attribute="type") | filter(attribute="breaking_change", value=true) -%}
+
+{% if breaking_commits | length > 0 -%}
+#### Breaking Changes
+{% for scope, scoped_commits in breaking_commits | group_by(attribute="scope") -%}
+
+{% for commit in scoped_commits | sort(attribute="scope") -%}
+    {% if commit.author and repository_url -%}
+        {% set author = "@" ~ commit.author -%}
+        {% set author_link = platform ~ "/" ~ commit.author -%}
+        {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+    {% set commit_link = repository_url ~ "/commit/" ~ commit.id -%}
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - **({{ scope }})** {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
+{% endfor -%}
+
+{% endfor -%}
+
+{% for commit in breaking_commits | unscoped -%}
+    {% if commit.author and repository_url -%}
+        {% set author = "@" ~ commit.author -%}
+        {% set author_link = platform ~ "/" ~ commit.author -%}
+        {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+    {% set commit_link = repository_url ~ "/commit/" ~ commit.id -%}
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
+{% endfor -%}
+
+{% endif -%}
+
+{% for type, typed_commits in commits | sort(attribute="type") | filter(attribute="breaking_change", value=false) | group_by(attribute="type") -%}
+
+#### {{ type | upper_first }}
+{% for scope, scoped_commits in typed_commits | group_by(attribute="scope") -%}
+
+{% for commit in scoped_commits | sort(attribute="scope") -%}
+    {% if commit.author and repository_url -%}
+        {% set author = "@" ~ commit.author -%}
+        {% set author_link = platform ~ "/" ~ commit.author -%}
+        {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+    {% set commit_link = repository_url ~ "/commit/" ~ commit.id -%}
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - **({{ scope }})** {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
+{% endfor -%}
+
+{% endfor -%}
+
+{% for commit in typed_commits | unscoped -%}
+    {% if commit.author and repository_url -%}
+        {% set author = "@" ~ commit.author -%}
+        {% set author_link = platform ~ "/" ~ commit.author -%}
+        {% set author = "[" ~ author ~ "](" ~ author_link ~ ")" -%}
+    {% else -%}
+        {% set author = commit.signature -%}
+    {% endif -%}
+    {% set commit_link = repository_url ~ "/commit/" ~ commit.id -%}
+    {% set shorthand = commit.id | truncate(length=7, end="") -%}
+    - {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
+{% endfor -%}
+
+{% endfor -%}


### PR DESCRIPTION
This commit adds the ability to use cocogitto to automate versioning and releasing to Github. It:

1. Defines a custom template to use for CHANGELOG generation. This template is a variation of the built-in "remote" template file, but it handles BREAKING CHANGES separately and up-front. Template files are based on the Tera template engine https://keats.github.io/tera/

2. Adds a cog.toml file for configuring cocogitto cog commands.

3. Adds a Github workflow to use the cocogitto published action to generate a version and a changelog and then push it as a new github release. This workflow can only be run manually.