### PR TITLE
fix: Redact ZHAL network blob from debug prints

### DIFF
--- a/libs/zhal/c/src/zhalDataScrubber.c
+++ b/libs/zhal/c/src/zhalDataScrubber.c
@@ -1,0 +1,47 @@
+//------------------------------ tabstop = 4 ----------------------------------
+//
+// Copyright (C) 2025 Comcast Corporation
+//
+// All rights reserved.
+//
+// This software is protected by copyright laws of the United States
+// and of foreign countries. This material may also be protected by
+// patent laws of the United States and of foreign countries.
+//
+// This software is furnished under a license agreement and/or a
+// nondisclosure agreement and may only be used or copied in accordance
+// with the terms of those agreements.
+//
+// The mere transfer of this software does not imply any licenses of trade
+// secrets, proprietary technology, copyrights, patents, trademarks, or
+// any other form of intellectual property whatsoever.
+//
+// Comcast Corporation retains all ownership rights.
+//
+//------------------------------ tabstop = 4 ----------------------------------
+
+/*
+ * Created by Raiyan Chowdhury on 2/21/25.
+ */
+
+#include <pthread.h>
+#include <icUtil/regexUtils.h>
+#include "zhalDataScrubber.h"
+
+REGEX_SIMPLE_REPLACER(NETWORK_CONFIG_DATA_REPLACER, "\"networkConfigData\":\"\\([^\"]*\\)\"", NULL, "<REDACTED>");
+static RegexReplacer *SENSITIVE_DATA_REPLACERS[] = { &NETWORK_CONFIG_DATA_REPLACER, NULL };
+
+static pthread_once_t init_once = PTHREAD_ONCE_INIT;
+
+static void initializeZhalDataScrubber()
+{
+    regexInitReplacers(SENSITIVE_DATA_REPLACERS);
+}
+
+char *zhalFilterJsonForLog(const cJSON *event)
+{
+    pthread_once(&init_once, initializeZhalDataScrubber);
+
+    scoped_generic char *eventString = cJSON_PrintUnformatted(event);
+    return regexReplace(eventString, SENSITIVE_DATA_REPLACERS);
+}

--- a/libs/zhal/c/src/zhalDataScrubber.h
+++ b/libs/zhal/c/src/zhalDataScrubber.h
@@ -1,0 +1,37 @@
+//------------------------------ tabstop = 4 ----------------------------------
+//
+// Copyright (C) 2025 Comcast Corporation
+//
+// All rights reserved.
+//
+// This software is protected by copyright laws of the United States
+// and of foreign countries. This material may also be protected by
+// patent laws of the United States and of foreign countries.
+//
+// This software is furnished under a license agreement and/or a
+// nondisclosure agreement and may only be used or copied in accordance
+// with the terms of those agreements.
+//
+// The mere transfer of this software does not imply any licenses of trade
+// secrets, proprietary technology, copyrights, patents, trademarks, or
+// any other form of intellectual property whatsoever.
+//
+// Comcast Corporation retains all ownership rights.
+//
+//------------------------------ tabstop = 4 ----------------------------------
+
+/*
+ * Created by Raiyan Chowdhury on 2/21/25.
+ */
+
+#pragma once
+
+#include <cjson/cJSON.h>
+
+/**
+ * Convert the given cJSON object to a string for logging and filter out any sensitive data.
+ *
+ * @param str The string to scrub
+ * @return Pointer to a heap allocated string with the sensitive data replaced
+ */
+char *zhalFilterJsonForLog(const cJSON *event);

--- a/libs/zhal/c/src/zhalImpl.c
+++ b/libs/zhal/c/src/zhalImpl.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 
 #include "zhalAsyncReceiver.h"
+#include "zhalDataScrubber.h"
 #include "zhalEventHandler.h"
 #include "zhalPrivate.h"
 #include <cjson/cJSON.h>
@@ -865,9 +866,9 @@ static bool workOnItem(WorkItem *item, void *arg)
         return true;
     }
 
-    char *json = cJSON_PrintUnformatted(item->request);
-    icLogDebug(LOG_TAG, "Worker processing JSON: %s", json);
-    free(json);
+    // This filters out any sensitive data, if present, that should not be logged
+    scoped_generic char *filteredJson = zhalFilterJsonForLog(item->request);
+    icLogDebug(LOG_TAG, "Worker processing JSON: %s", filteredJson);
 
     // put in asyncRequests
     pthread_mutex_lock(&asyncRequestsMutex);


### PR DESCRIPTION
The networkConfigData contains the zigbee network key and should not be printed.

Refs: BARTON-291