### PR TITLE
chore: promote `app` to first class conventional commit type

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -64,6 +64,7 @@
 # - `style:` Changes that do not affect the meaning of the code
 #            (white-space, formatting, missing semi-colons, etc)
 # - `test:` Adding missing tests or correcting existing tests
+# - `app:` Changes to the Reference App (`reference/`)
 #
 # Scopes can include device drivers, subsystems, documentation or
 # nothing at all.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ Must be one of the following.
 -   `revert:` A commit that reverts a previous commit
 -   `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 -   `test:` Adding missing tests or correcting existing tests
+-   `app:` Changes to the Reference App (`reference/`)
 
 ##### Header: Scope
 


### PR DESCRIPTION
Need to be able to document features/fixes to the reference app without impacting semantic versioning of libBartonCore. This commit promotes `app` to a conventional commit type in our CONTRIBUTING doc and gitmessage hint.