### PR TITLE
build: remove BCORE_PROVIDE_LIBS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,9 +138,7 @@ if (BCORE_BUILD_WITH_ASAN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 endif()
 
-if (NOT BCORE_PROVIDE_LIBS)
-    add_subdirectory(libs)
-endif()
+add_subdirectory(libs)
 
 add_subdirectory(core)
 

--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -170,9 +170,6 @@ message(STATUS "- - - - - - - - - - - - - - - - ")
 message(STATUS "- - - - - - - - - - - - - - - - ")
 message(STATUS "Barton Core PRIVATE ON/OFF Configs. These options should not be used by new clients.")
 
-bcore_option(NAME BCORE_PROVIDE_LIBS
-           DEFINITION BARTON_CONFIG_PROVIDE_LIBS
-           DESCRIPTION "Choose if private libraries are provided by the client.")
 bcore_option(NAME BCORE_SUPPORT_ALARMS
            DEFINITION BARTON_CONFIG_SUPPORT_ALARMS
            DESCRIPTION "Whether alarms are supported by the client.")


### PR DESCRIPTION
The BCORE_PROVIDE_LIBS option existed to support an exisiting client of
Barton but is no longer needed, remove it.
