### PR TITLE
feat: migrate zigbee telemetry to property provider

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -195,6 +195,10 @@ bcore_string_option(NAME BCORE_MATTER_LIB
                   DEFINITION BARTON_CONFIG_MATTER_LIB
                   DESCRIPTION "Name of the provided Matter library."
                   VALUE "BartonMatter")
+bcore_string_option(NAME BCORE_DEBUG_TELEMETRY_UPLOAD_DIRECTORY
+                    DEFINITION BARTON_CONFIG_DEBUG_TELEMETRY_UPLOAD_DIRECTORY
+                    DESCRIPTION "Directory to which telemetry files are uploaded in debug builds."
+                    VALUE "/tmp/zigbeeTelemetry/upload")
 
 # We're not going to use BCoreMatterHelper to set up defaults (as BCoreMatterHelper applies FORCE
 # sets). However, include it to populate default header paths.

--- a/core/src/devicePrivateProperties.h
+++ b/core/src/devicePrivateProperties.h
@@ -34,6 +34,7 @@
 #define DEVICE_DESC_DENYLIST                                  "deviceDescriptor.blacklist"
 #define POSIX_TIME_ZONE_PROP                                  "POSIX_TZ"
 #define DEVICE_FIRMWARE_URL_NODE                              "deviceFirmwareBaseUrl"
+#define DEVICE_STATIC_STORAGE_DIRECTORY                       "device.staticStorageDirectory"
 #define CPE_DENYLISTED_DEVICES_PROPERTY_NAME                  "cpe.denylistedDevices"
 #define TOUCHSCREEN_SENSOR_COMMFAIL_TROUBLE_DELAY             "touchscreen.sensor.commFail.troubleDelay"
 #define ZIGBEE_PROPS_PREFIX                                   "cpe.zigbee."

--- a/core/src/subsystems/zigbee/zigbeeTelemetryProperties.h
+++ b/core/src/subsystems/zigbee/zigbeeTelemetryProperties.h
@@ -1,0 +1,33 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Kevin Funderburg on 10/7/2025.
+//
+
+#pragma once
+
+#define TELEMETRY_MAX_ALLOWED_FILE_STORAGE "telemetry.maxAllowedFileStorage"
+#define TELEMETRY_HOURS_REMAINING          "telemetry.hoursRemaining"
+#define TELEMETRY_ALLOW_UPLOAD             "telemetry.upload"
+#define TELEMETRY_CAPABILITIES             "telemetry.capabilities"


### PR DESCRIPTION
Stacked PRs:
 * #89
 * __->__#88


--- --- ---

### feat: migrate zigbee telemetry to property provider


Migrate zigbeeTelemetry.c from legacy propsMgr to the new property
provider system for improved consistency and maintainability.

Changes:
- Replace propsMgr calls with BCorePropertyProvider APIs
- Add zigbeeTelemetryProperties.h with telemetry property constants
- Define BCORE_DEBUG_TELEMETRY_UPLOAD_DIRECTORY config option
- Add DEVICE_STATIC_STORAGE_DIRECTORY property for storage paths
- Update property access patterns to use provider getters/setters
- Remove deprecated propsMgr includes and dependencies

This migration aligns zigbee telemetry with the standardized property
management approach used throughout the codebase.
