### PR TITLE
feat: Matter power source cluster and battery attributes

### DIFF
--- a/core/deviceDrivers/matter/clusters/PowerSource.cpp
+++ b/core/deviceDrivers/matter/clusters/PowerSource.cpp
@@ -1,0 +1,100 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Raiyan Chowdhury on 8/16/24.
+//
+
+#define LOG_TAG     "PowerSourceCluster"
+#define logFmt(fmt) "(%s): " fmt, __func__
+
+extern "C" {
+#include <icLog/logging.h>
+}
+
+#include "PowerSource.h"
+#include "app/ConcreteAttributePath.h"
+#include "lib/core/CHIPError.h"
+
+using namespace chip::app::Clusters::PowerSource;
+
+namespace barton
+{
+    void PowerSource::OnAttributeChanged(chip::app::ClusterStateCache *cache,
+                                         const chip::app::ConcreteAttributePath &path)
+    {
+        using namespace chip::app;
+
+        if (path.mEndpointId != endpointId || path.mClusterId != Clusters::PowerSource::Id)
+        {
+            return;
+        }
+
+        switch (path.mAttributeId)
+        {
+            case Attributes::BatChargeLevel::Id:
+            {
+                using TypeInfo = Attributes::BatChargeLevel::TypeInfo;
+
+                TypeInfo::DecodableType value;
+                CHIP_ERROR error = cache->Get<TypeInfo>(path, value);
+
+                if (error == CHIP_NO_ERROR)
+                {
+                    static_cast<PowerSource::EventHandler *>(eventHandler)->BatChargeLevelChanged(deviceId, value);
+                }
+                else
+                {
+                    icError("Failed to read BatChargeLevel report from device %s: %s", deviceId.c_str(),
+                                                                                      error.AsString());
+                }
+
+                break;
+            }
+
+            case Attributes::BatPercentRemaining::Id:
+            {
+                using TypeInfo = Attributes::BatPercentRemaining::TypeInfo;
+
+                TypeInfo::DecodableType value;
+                CHIP_ERROR error = cache->Get<TypeInfo>(path, value);
+
+                if (error == CHIP_NO_ERROR)
+                {
+                    static_cast<PowerSource::EventHandler *>(eventHandler)->
+                        BatPercentRemainingChanged(deviceId, value.Value());
+                }
+                else
+                {
+                    icError("Failed to read BatPercentRemaining report from device %s: %s", deviceId.c_str(),
+                                                                                           error.AsString());
+                }
+
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+} // namespace barton

--- a/core/deviceDrivers/matter/clusters/PowerSource.h
+++ b/core/deviceDrivers/matter/clusters/PowerSource.h
@@ -1,0 +1,58 @@
+// ------------------------------ tabstop = 4 ----------------------------------
+//
+// If not stated otherwise in this file or this component's LICENSE file the
+// following copyright and licenses apply:
+//
+// Copyright 2025 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------------------ tabstop = 4 ----------------------------------
+
+//
+// Created by Raiyan Chowdhury on 8/16/24.
+//
+
+#pragma once
+
+#include "MatterCluster.h"
+#include "app/ClusterStateCache.h"
+#include "app/ConcreteAttributePath.h"
+#include "lib/core/CHIPError.h"
+#include "lib/core/DataModelTypes.h"
+#include <string>
+
+namespace barton
+{
+    class PowerSource : public MatterCluster
+    {
+    public:
+        PowerSource(EventHandler *handler, const std::string deviceId, chip::EndpointId endpointId,
+                    std::shared_ptr<DeviceDataCache> deviceDataCache) :
+            MatterCluster(handler, deviceId, endpointId, chip::app::Clusters::PowerSource::Id, deviceDataCache)
+        {
+        }
+
+        class EventHandler : public MatterCluster::EventHandler
+        {
+        public:
+            virtual void BatChargeLevelChanged(std::string &deviceUuid, chip::app::Clusters::PowerSource::BatChargeLevelEnum chargeLevel) {};
+            virtual void BatPercentRemainingChanged(std::string &deviceUuid, uint8_t halfPercent) {};
+        };
+
+        void OnAttributeChanged(chip::app::ClusterStateCache *cache,
+                                const chip::app::ConcreteAttributePath &path) override;
+    };
+} // namespace barton

--- a/core/src/subsystems/matter/DeviceDataCache.h
+++ b/core/src/subsystems/matter/DeviceDataCache.h
@@ -144,6 +144,13 @@ namespace barton
         chip::Optional<NetworkUtils::NetworkInterfaceInfo> GetInterfaceInfo() const;
 
         /**
+         * Check the device's power source type.
+         * TODO: Account for multiple power sources (i.e. PowerSource clusters on multiple endpoints).
+         */
+        CHIP_ERROR IsBatteryPowered(bool &isBattery) const;
+        CHIP_ERROR IsWiredPowered(bool &isWired) const;
+
+        /**
          * Trigger a full reprocessing of the cache's attribute data as if a full attribute report was
          * received, invoking report and attribute callbacks (events not reprocessed).
          *
@@ -292,6 +299,8 @@ namespace barton
 
         SubscriptionIntervalSecs CalculateFinalSubscriptionIntervalSecs();
 
+        // TODO: Account for multiple power sources (i.e. PowerSource clusters on multiple endpoints).
+        CHIP_ERROR GetPowerSourceFeatureMap(uint32_t &featureMap) const;
 
         /**
          * Get a JSON representation of all clusters and attributes for a given endpoint.


### PR DESCRIPTION
Add support for the Matter power source cluster and track changes in the battery percentage. Assumes one power source per device for now.

Known Issues:
- Most of the example apps in the Matter SDK (excluding a few like the all-clusters-app) do not implement the PowerSource cluster (probably for simplicity's sake). If we were to fail the commissioning process whenever we failed to initialize a PowerSource cluster, then we'd fail to commission most of these example apps during testing, so the code was written so that commissioning proceeds regardless.

Refs: BARTON-305