### PR TITLE
build(matter): Backport thread stack change

### DIFF
--- a/third_party/matter/barton-library/patches/0001-Fix-reading-ExtendedAddress-from-otbr-agent-39723.patch
+++ b/third_party/matter/barton-library/patches/0001-Fix-reading-ExtendedAddress-from-otbr-agent-39723.patch
@@ -1,0 +1,162 @@
+From b92628b9b11966b49c2b34cafe7a09bee23ccd71 Mon Sep 17 00:00:00 2001
+From: Thomas Lea <thomas_lea@comcast.com>
+Date: Tue, 8 Jul 2025 11:43:46 -0500
+Subject: [PATCH 1/2] Fix reading ExtendedAddress from otbr-agent (#39723)
+
+* Fix reading ExtendedAddress from otbr-agent
+
+The property is defined to not emit signals on changes, which means
+the generated caching proxy will never have a value. Instead, we must
+directly read the value with the Get function and cache it ourselves.
+
+Fixes #39722
+
+* Review fixes
+
+- added missing error return
+- use CHIP_ERROR_KEY_NOT_FOUND instead of CHIP_ERROR_INTERNAL, following
+  _GetThreadProvision implementation.
+
+* restyled
+
+* review comments
+
+use VerifyOrReturnError for neatness.
+
+* Remove unused DBusOpenthread properties
+
+Since Linux platform uses a caching proxy to read OpenThread properties
+over dbus, it will not provide values for properties annotated as
+EmitsChangedSignal=false, so it is misleading and error-prone to
+generate get function accessors for those. These properties were
+therefore removed from generation. They werent being used anyway.
+
+* Revert "Remove unused DBusOpenthread properties"
+
+This reverts commit 923a8da01a294e82d98a7534d63f17b5a341b43a.
+
+* make referenced otbr dbus props writable only
+
+They are being written to, so the caching proxy isnt an issue
+but we still need the properties in the generated interface.
+---
+ src/platform/Linux/ThreadStackManagerImpl.cpp | 41 +++++++++++++++++--
+ src/platform/Linux/ThreadStackManagerImpl.h   |  1 +
+ .../Linux/dbus/openthread/DBusOpenthread.xml  | 13 ++----
+ 3 files changed, 41 insertions(+), 14 deletions(-)
+
+diff --git a/src/platform/Linux/ThreadStackManagerImpl.cpp b/src/platform/Linux/ThreadStackManagerImpl.cpp
+index a67942be..96d82a1d 100644
+--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
++++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
+@@ -546,14 +546,47 @@ CHIP_ERROR ThreadStackManagerImpl::_GetAndLogThreadTopologyFull()
+ CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
+ {
+     VerifyOrReturnError(mProxy, CHIP_ERROR_INCORRECT_STATE);
+-    guint64 extAddr = openthread_border_router_get_extended_address(mProxy.get());
+ 
+-    for (size_t i = 0; i < sizeof(extAddr); i++)
++    // The ExtendedAddress d-bus property from otbr-agent is defined to not emit changed signals.
++    // This means the generated api, which uses a caching proxy underneath, will not obtain a value
++    // and will always return NULL. In order to retrieve the value in this case, we must directly
++    // call the Get function to get it, then we manually cache locally since it does not change.
++    if (std::all_of(mExtendedAddress, mExtendedAddress + sizeof(mExtendedAddress), [](uint8_t v) { return v == 0; }))
+     {
+-        buf[sizeof(uint64_t) - i - 1] = (extAddr & UINT8_MAX);
+-        extAddr >>= CHAR_BIT;
++        GAutoPtr<GError> err;
++        GAutoPtr<GVariant> response(g_dbus_proxy_call_sync(G_DBUS_PROXY(mProxy.get()), "org.freedesktop.DBus.Properties.Get",
++                                                           g_variant_new("(ss)", "io.openthread.BorderRouter", "ExtendedAddress"),
++                                                           G_DBUS_CALL_FLAGS_NONE, -1, nullptr, &err.GetReceiver()));
++
++        VerifyOrReturnError(err == nullptr, CHIP_ERROR_INTERNAL,
++                            ChipLogError(DeviceLayer, "openthread: failed to read ExtendedAddress property: %s", err->message));
++
++        VerifyOrReturnError(response, CHIP_ERROR_KEY_NOT_FOUND,
++                            ChipLogError(DeviceLayer, "openthread: failed to get a response for ExtendedAddress property"));
++
++        GAutoPtr<GVariant> tupleContent(g_variant_get_child_value(response.get(), 0));
++
++        VerifyOrReturnError(tupleContent, CHIP_ERROR_KEY_NOT_FOUND,
++                            ChipLogError(DeviceLayer, "openthread: failed to find tuple in ExtendedAddress response"));
++
++        GAutoPtr<GVariant> value(g_variant_get_variant(tupleContent.get()));
++
++        VerifyOrReturnError(value, CHIP_ERROR_KEY_NOT_FOUND,
++                            ChipLogError(DeviceLayer, "openthread: failed to find tuple value in ExtendedAddress response"));
++
++        VerifyOrReturnError(g_variant_is_of_type(value.get(), G_VARIANT_TYPE_UINT64), CHIP_ERROR_KEY_NOT_FOUND,
++                            ChipLogError(DeviceLayer, "openthread: ExtendedAddress property returned unexpected type: %s",
++                                         g_variant_get_type_string(value.get())));
++
++        guint64 address_value = g_variant_get_uint64(value.get());
++        for (size_t i = 0; i < sizeof(address_value); i++)
++        {
++            mExtendedAddress[sizeof(mExtendedAddress) - i - 1] = (address_value & UINT8_MAX);
++            address_value >>= CHAR_BIT;
++        }
+     }
+ 
++    memcpy(buf, mExtendedAddress, sizeof(mExtendedAddress));
+     return CHIP_NO_ERROR;
+ }
+ 
+diff --git a/src/platform/Linux/ThreadStackManagerImpl.h b/src/platform/Linux/ThreadStackManagerImpl.h
+index 20cf85f2..48c32592 100755
+--- a/src/platform/Linux/ThreadStackManagerImpl.h
++++ b/src/platform/Linux/ThreadStackManagerImpl.h
+@@ -165,6 +165,7 @@ private:
+     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
+ 
+     bool mAttached;
++    uint8_t mExtendedAddress[8];
+ };
+ 
+ inline void ThreadStackManagerImpl::_OnThreadAttachFinished(void)
+diff --git a/src/platform/Linux/dbus/openthread/DBusOpenthread.xml b/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
+index 3e48e5ca..a309ab64 100644
+--- a/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
++++ b/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
+@@ -75,7 +75,7 @@ the OpenThread integration with the Matter SDK.
+       bool device_type        // ftd or mtd
+       bool network_data       // full or stable
+     -->
+-    <property name="LinkMode" type="(bbb)" access="readwrite">
++    <property name="LinkMode" type="(bbb)" access="write">
+       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+     </property>
+ 
+@@ -93,13 +93,6 @@ the OpenThread integration with the Matter SDK.
+       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+     </property>
+ 
+-    <!--
+-    The 64-bit extended address.
+-    -->
+-    <property name="ExtendedAddress" type="t" access="read">
+-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+-    </property>
+-
+     <!--
+     The list of current external route rules.
+ 
+@@ -115,14 +108,14 @@ the OpenThread integration with the Matter SDK.
+         bool next_hop_is_self
+       }
+     -->
+-    <property name="ExternalRoutes" type="a((ayy)qybb)" access="read">
++    <property name="ExternalRoutes" type="a((ayy)qybb)" access="write">
+       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+     </property>
+ 
+     <!--
+     The Thread active dataset TLV in binary form.
+     -->
+-    <property name="ActiveDatasetTlvs" type="ay" access="readwrite">
++    <property name="ActiveDatasetTlvs" type="ay" access="write">
+       <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+     </property>
+-- 
+2.43.0
+

--- a/third_party/matter/barton-library/patches/0002-Patch-out-visibility-restriction.patch
+++ b/third_party/matter/barton-library/patches/0002-Patch-out-visibility-restriction.patch
@@ -1,7 +1,7 @@
-From af71e6e566366cc3bf683c0eabf49bec2e1d6465 Mon Sep 17 00:00:00 2001
+From b4b4d89d536689913bd17f308d93c51e033333be Mon Sep 17 00:00:00 2001
 From: Christian Leithner <christian_leithner@comcast.com>
 Date: Mon, 15 Sep 2025 20:00:33 +0000
-Subject: [PATCH] Patch out visibility restriction
+Subject: [PATCH 2/2] Patch out visibility restriction
 
 For some reason, the SDK put in a gn restriction for the required-privileges
 source_set that prevents any gn from using it either directly or transitively
@@ -37,9 +37,9 @@ index 40cb416c..09e5c8d3 100644
 +  #   "${chip_root}/src/controller/data_model",
 +  #   "${chip_root}/src/data-model-providers/codegen/*",
 +  # ]
-
+ 
    # We still have some strong coupling in this case
    # Eventually dynamic server should be replaced with code-driven and not try
---
+-- 
 2.43.0
 


### PR DESCRIPTION
A change to the Matter SDK was made 3 months ago that we had in meta-rdk-iot but not elsewhere. This change backports a newer variant of that commit (what was actually merged into the Matter SDK) and reorders patches.

https://github.com/project-chip/connectedhomeip/commit/6b2785110801d5d19fa67ac735a4c774995356a1