### PR TITLE
build: add option for OTA Provider support

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -164,6 +164,9 @@ bcore_option(NAME BCORE_MATTER_SKIP_SDK
 bcore_option(NAME BCORE_MATTER_USE_DEFAULT_COMMISSIONABLE_DATA
            DEFINITION BARTON_CONFIG_USE_DEFAULT_COMMISSIONABLE_DATA
            DESCRIPTION "Use default commissionable data values instead of ones provided by the client")
+bcore_option(NAME BCORE_MATTER_ENABLE_OTA_PROVIDER
+           DEFINITION BARTON_CONFIG_MATTER_ENABLE_OTA_PROVIDER
+           DESCRIPTION "Enable OTA provider for Matter and configure devices with OTA Requestor cluster")
 
 message(STATUS "- - - - - - - - - - - - - - - - ")
 

--- a/core/deviceDrivers/matter/MatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterDeviceDriver.cpp
@@ -335,12 +335,14 @@ void MatterDeviceDriver::ConfigureDevice(std::forward_list<std::promise<bool>> &
 
     using namespace chip::app::Clusters;
 
+#ifdef BARTON_CONFIG_MATTER_ENABLE_OTA_PROVIDER
     if (!ConfigureOTARequestorCluster(promises, deviceId, deviceDescriptor, exchangeMgr, sessionHandle))
     {
         icError("Failed to configure OTA Requestor for device %s", deviceId.c_str());
         FailOperation(promises);
         return;
     }
+#endif
 
     DoConfigureDevice(promises, deviceId, deviceDescriptor, exchangeMgr, sessionHandle);
 


### PR DESCRIPTION
If a device does not have support for the OTA Provider cluster, it should not configure the OTA Requestor cluster on devices that are commissioned. This new option defaults to unset.

Refs: BARTON-315