### PR TITLE
build: standardize on docker compose commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,7 @@
     // NOTE: VSC will copy some files post-config; .ssh/known_hosts, .gitconfig, etc
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind",
-        "target=/tmp,type=tmpfs"
+        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind"
     ],
 
     // By setting this value to true, VSC will not run the entrypoint/CMD in the Dockerfile

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -32,8 +32,6 @@ if [ ! -f $docker_env_path ]; then
 fi
 
 # The image tag is stored in the .env file and is generated when running `setupDockerEnv.sh`.
-# The default tag is 'latest', so if you want to build a specific tag, edit the value of
-# `IMAGE_TAG` within `docker/.env`.
-source $docker_env_path
+# If you want to build a specific tag, edit the value of `IMAGE_TAG` within `docker/.env`.
 
-docker build -t $IMAGE_REPO:$IMAGE_TAG ${script_dir}
+docker compose -f ${script_dir}/compose.yaml build

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -56,6 +56,8 @@ services:
         volumes:
             # Mount the barton source code on the host into the same path within container.
             - ..:/$BARTON_TOP:cached
+        tmpfs:
+            - /tmp:exec
 
 networks:
     barton-ip6net:

--- a/dockerw
+++ b/dockerw
@@ -28,17 +28,20 @@ notice() {
 
 set -e
 
-INTERACTIVE_FLAGS="-it"
+if [ -f /.dockerenv ]; then
+    echo "ERROR: dockerw is already running inside a container."
+    echo "Run commands directly in the current container instead of nesting containers."
+    exit 1
+fi
+
+COMPOSE_INTERACTIVE_FLAGS=""
 EXTRA_ENV="-e SSH_AUTH_SOCK"
 DEV_VOL=""
 
-while getopts ":npe:t:d" opt; do
+while getopts ":ne:t:d" opt; do
     case ${opt} in
     n) # process option n
-        INTERACTIVE_FLAGS=""
-        ;;
-    p) # pull docker
-        docker pull $IMAGE
+        COMPOSE_INTERACTIVE_FLAGS="--no-TTY"
         ;;
     e) # extra environment variables
         EXTRA_ENV="${EXTRA_ENV} -e ${OPTARG}"
@@ -55,43 +58,24 @@ DIR=$(pwd)
 # generate the `docker/.env` file and ensure the network/image is created
 $DIR/docker/setupDockerEnv.sh
 
-DOCKER_ENV_PATH="$DIR/docker/.env"
-
-# to build/use an image with a custom tag, the tag must be stored in the
-# `docker/.env` file as `IMAGE_TAG=some-tag`
-IMAGE_TAG=$(grep "IMAGE_TAG" "$DOCKER_ENV_PATH" | sed 's/IMAGE_TAG=//')
-IMAGE_REPO=$(grep "IMAGE_REPO" "$DOCKER_ENV_PATH" | sed 's/IMAGE_REPO=//')
-
-IMAGE="$IMAGE_REPO:$IMAGE_TAG"
+COMPOSE_FILE="${DIR}/docker/compose.yaml"
 
 EXTRA_VOLUMES="${DEV_VOL}"
 
-if [ -f /.dockerenv ]; then
-    CURR_CONTAINER=$(hostname)
-    VOLUMES_ARGS="--volumes-from $CURR_CONTAINER"
-else
-
-    VOLUMES_ARGS="-v $DIR:$DIR
-                 -v $HOME:$HOME
-                 --tmpfs /tmp:exec
-                 $EXTRA_VOLUMES"
-fi
+VOLUMES_ARGS="-v $HOME:$HOME
+             $EXTRA_VOLUMES"
 
 # create a unique container name prefixed with the user id, useful when on a shared machine
 USER_ID=$(id -u -n)
 RANDOM_NUMBER=$(shuf -i 100000-999999 -n 1)
 CONTAINER_NAME="${USER_ID}_${RANDOM_NUMBER}"
 
-docker run \
+docker compose -f "${COMPOSE_FILE}" run \
     --rm \
-    --name $CONTAINER_NAME \
-    $INTERACTIVE_FLAGS \
-    --privileged \
-    --network $USER-barton-ip6net \
-    --cap-add SYS_PTRACE \
-    $VOLUMES_ARGS \
-    -w "$DIR" \
-    --env-file $DOCKER_ENV_PATH \
-    $EXTRA_ENV \
-    $IMAGE \
+    --name ${CONTAINER_NAME} \
+    ${COMPOSE_INTERACTIVE_FLAGS} \
+    --workdir "${DIR}" \
+    ${VOLUMES_ARGS} \
+    ${EXTRA_ENV} \
+    barton \
     $*


### PR DESCRIPTION
Replace inconsistent docker commands with docker compose equivalents to unify container management approach across the project.

Changes:
- dockerw: Replace docker run with docker compose run for consistency
- build.sh: Use docker compose build instead of docker build
- Add tmpfs mount to compose.yaml for /tmp:exec compatibility
- Remove --volumes-from (unsupported in compose) and add container nesting prevention
- Simplify volume management: compose handles base mounts, dockerw adds dynamic user-specific volumes ($HOME, /dev)
- Remove unused -p flag from dockerw
- Update devcontainer mounts to align with compose configuration

This establishes compose as the single source of truth for container configuration while maintaining existing functionality.

Refs: BARTON-180