### PR TITLE
feat: Matter WiFi signal strength reporting

### DIFF
--- a/core/deviceDrivers/matter/MatterContactSensorDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterContactSensorDeviceDriver.cpp
@@ -140,12 +140,12 @@ bool MatterContactSensorDeviceDriver::DoRegisterResources(icDevice *device)
     return result;
 }
 
-void MatterContactSensorDeviceDriver::ReadResource(std::forward_list<std::promise<bool>> &promises,
-                                                   const std::string &deviceId,
-                                                   icDeviceResource *resource,
-                                                   char **value,
-                                                   chip::Messaging::ExchangeManager &exchangeMgr,
-                                                   const chip::SessionHandle &sessionHandle)
+void MatterContactSensorDeviceDriver::DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                                                     const std::string &deviceId,
+                                                     icDeviceResource *resource,
+                                                     char **value,
+                                                     chip::Messaging::ExchangeManager &exchangeMgr,
+                                                     const chip::SessionHandle &sessionHandle)
 {
     icDebug("%s", resource->id);
 

--- a/core/deviceDrivers/matter/MatterContactSensorDeviceDriver.h
+++ b/core/deviceDrivers/matter/MatterContactSensorDeviceDriver.h
@@ -49,12 +49,12 @@ namespace barton
 
         bool DoRegisterResources(icDevice *device) override;
 
-        void ReadResource(std::forward_list<std::promise<bool>> &promises,
-                          const std::string &deviceId,
-                          icDeviceResource *resource,
-                          char **value,
-                          chip::Messaging::ExchangeManager &exchangeMgr,
-                          const chip::SessionHandle &sessionHandle) override;
+        void DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                            const std::string &deviceId,
+                            icDeviceResource *resource,
+                            char **value,
+                            chip::Messaging::ExchangeManager &exchangeMgr,
+                            const chip::SessionHandle &sessionHandle) override;
 
         void SetTampered(const std::string &deviceId, bool tampered) override;
 

--- a/core/deviceDrivers/matter/MatterDoorLockDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterDoorLockDeviceDriver.cpp
@@ -144,12 +144,12 @@ bool MatterDoorLockDeviceDriver::DoRegisterResources(icDevice *device)
     return result;
 }
 
-void MatterDoorLockDeviceDriver::ReadResource(std::forward_list<std::promise<bool>> &promises,
-                                              const std::string &deviceId,
-                                              icDeviceResource *resource,
-                                              char **value,
-                                              chip::Messaging::ExchangeManager &exchangeMgr,
-                                              const chip::SessionHandle &sessionHandle)
+void MatterDoorLockDeviceDriver::DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                                                const std::string &deviceId,
+                                                icDeviceResource *resource,
+                                                char **value,
+                                                chip::Messaging::ExchangeManager &exchangeMgr,
+                                                const chip::SessionHandle &sessionHandle)
 {
     bool asyncCleanup = false;
 

--- a/core/deviceDrivers/matter/MatterDoorLockDeviceDriver.h
+++ b/core/deviceDrivers/matter/MatterDoorLockDeviceDriver.h
@@ -57,12 +57,12 @@ namespace barton
 
         bool DoRegisterResources(icDevice *device) override;
 
-        void ReadResource(std::forward_list<std::promise<bool>> &promises,
-                          const std::string &deviceId,
-                          icDeviceResource *resource,
-                          char **value,
-                          chip::Messaging::ExchangeManager &exchangeMgr,
-                          const chip::SessionHandle &sessionHandle) override;
+        void DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                            const std::string &deviceId,
+                            icDeviceResource *resource,
+                            char **value,
+                            chip::Messaging::ExchangeManager &exchangeMgr,
+                            const chip::SessionHandle &sessionHandle) override;
 
         bool WriteResource(std::forward_list<std::promise<bool>> &promises,
                            const std::string &deviceId,

--- a/core/deviceDrivers/matter/MatterLightDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterLightDeviceDriver.cpp
@@ -160,12 +160,12 @@ bool MatterLightDeviceDriver::DoRegisterResources(icDevice *device)
     return result;
 }
 
-void MatterLightDeviceDriver::ReadResource(std::forward_list<std::promise<bool>> &promises,
-                                           const std::string &deviceId,
-                                           icDeviceResource *resource,
-                                           char **value,
-                                           chip::Messaging::ExchangeManager &exchangeMgr,
-                                           const chip::SessionHandle &sessionHandle)
+void MatterLightDeviceDriver::DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                                             const std::string &deviceId,
+                                             icDeviceResource *resource,
+                                             char **value,
+                                             chip::Messaging::ExchangeManager &exchangeMgr,
+                                             const chip::SessionHandle &sessionHandle)
 {
     bool asyncCleanup = false;
 

--- a/core/deviceDrivers/matter/MatterLightDeviceDriver.h
+++ b/core/deviceDrivers/matter/MatterLightDeviceDriver.h
@@ -56,12 +56,12 @@ namespace barton
 
         bool DoRegisterResources(icDevice *device) override;
 
-        void ReadResource(std::forward_list<std::promise<bool>> &promises,
-                          const std::string &deviceId,
-                          icDeviceResource *resource,
-                          char **value,
-                          chip::Messaging::ExchangeManager &exchangeMgr,
-                          const chip::SessionHandle &sessionHandle) override;
+        void DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                            const std::string &deviceId,
+                            icDeviceResource *resource,
+                            char **value,
+                            chip::Messaging::ExchangeManager &exchangeMgr,
+                            const chip::SessionHandle &sessionHandle) override;
 
         bool WriteResource(std::forward_list<std::promise<bool>> &promises,
                            const std::string &deviceId,

--- a/core/deviceDrivers/matter/MatterWindowCoveringDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterWindowCoveringDeviceDriver.cpp
@@ -156,12 +156,12 @@ bool MatterWindowCoveringDeviceDriver::DoRegisterResources(icDevice *device)
     return result;
 }
 
-void MatterWindowCoveringDeviceDriver::ReadResource(std::forward_list<std::promise<bool>> &promises,
-                                                    const std::string &deviceId,
-                                                    icDeviceResource *resource,
-                                                    char **value,
-                                                    chip::Messaging::ExchangeManager &exchangeMgr,
-                                                    const chip::SessionHandle &sessionHandle)
+void MatterWindowCoveringDeviceDriver::DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                                                      const std::string &deviceId,
+                                                      icDeviceResource *resource,
+                                                      char **value,
+                                                      chip::Messaging::ExchangeManager &exchangeMgr,
+                                                      const chip::SessionHandle &sessionHandle)
 {
     bool asyncCleanup = false;
 

--- a/core/deviceDrivers/matter/MatterWindowCoveringDeviceDriver.h
+++ b/core/deviceDrivers/matter/MatterWindowCoveringDeviceDriver.h
@@ -56,12 +56,12 @@ namespace barton
 
         bool DoRegisterResources(icDevice *device) override;
 
-        void ReadResource(std::forward_list<std::promise<bool>> &promises,
-                          const std::string &deviceId,
-                          icDeviceResource *resource,
-                          char **value,
-                          chip::Messaging::ExchangeManager &exchangeMgr,
-                          const chip::SessionHandle &sessionHandle) override;
+        void DoReadResource(std::forward_list<std::promise<bool>> &promises,
+                            const std::string &deviceId,
+                            icDeviceResource *resource,
+                            char **value,
+                            chip::Messaging::ExchangeManager &exchangeMgr,
+                            const chip::SessionHandle &sessionHandle) override;
 
         bool WriteResource(std::forward_list<std::promise<bool>> &promises,
                            const std::string &deviceId,

--- a/core/deviceDrivers/matter/clusters/MatterCluster.h
+++ b/core/deviceDrivers/matter/clusters/MatterCluster.h
@@ -118,6 +118,30 @@ namespace barton
         void *commandContext {};      // only one command operation can be in flight at a time
         void *writeRequestContext {}; // only one write request operation can be in flight at a time
 
+        /**
+         * Context for on-demand attribute reads that send a read request to the device rather than query the cluster
+         * state cache for the attribute value.
+         */
+        struct OnDemandReadContext
+        {
+            /**
+             * @brief Construct a new OnDemandReadContext object
+             *
+             * @param context The caller's context pointer to be passed back in the read complete callback
+             * @param eventHandler The cluster's event handler to invoke the read complete callback on
+             * @param deviceId The device UUID of the device being red from
+            */
+            OnDemandReadContext(void *context,
+                                MatterCluster::EventHandler *eventHandler,
+                                std::string &deviceId) :
+                baseReadContext(context), eventHandler(eventHandler), deviceId(deviceId)
+            {
+            }
+            void *baseReadContext;
+            MatterCluster::EventHandler *eventHandler;
+            std::string &deviceId;
+        };
+
         bool
         SendCommand(chip::app::CommandSender *commandSender, const chip::SessionHandle &sessionHandle, void *context);
 

--- a/core/deviceDrivers/matter/clusters/WifiNetworkDiagnostics.cpp
+++ b/core/deviceDrivers/matter/clusters/WifiNetworkDiagnostics.cpp
@@ -37,75 +37,65 @@ extern "C" {
 #include <icLog/logging.h>
 }
 
+#include <memory>
 #include "WifiNetworkDiagnostics.h"
 #include "app-common/zap-generated/ids/Attributes.h"
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "app/BufferedReadCallback.h"
 #include "app/InteractionModelEngine.h"
 
-namespace barton
-{
-    void WifiNetworkDiagnostics::OnAttributeChanged(chip::app::ClusterStateCache *cache,
-                                                    const chip::app::ConcreteAttributePath &path)
-    {
-        using namespace chip::app::Clusters::WiFiNetworkDiagnostics;
-        using TypeInfo = Attributes::Rssi::TypeInfo;
+using namespace barton;
 
-        if (path.mClusterId == chip::app::Clusters::WiFiNetworkDiagnostics::Id &&
-            path.mAttributeId == chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::Rssi::Id)
-        {
-            TypeInfo::DecodableType value;
-            CHIP_ERROR error = cache->Get<TypeInfo>(path, value);
-            if (error == CHIP_NO_ERROR)
-            {
-                int8_t *nullableValue = value.IsNull() ? nullptr : &value.Value();
-                static_cast<WifiNetworkDiagnostics::EventHandler *>(eventHandler)
-                    ->RssiChanged(deviceId, nullableValue, nullptr);
-            }
-            else
-            {
-                icError("Failed to decode rssi attribute: %s", error.AsString());
-            }
-        }
-        else
-        {
-            icTrace("Unexpected cluster or attribute");
-        }
+bool WifiNetworkDiagnostics::GetRssi(void *context,
+                                     chip::Messaging::ExchangeManager &exchangeMgr,
+                                     const chip::SessionHandle &sessionHandle)
+{
+    icDebug();
+
+    using namespace chip::app::Clusters::WiFiNetworkDiagnostics;
+    using TypeInfo = Attributes::Rssi::TypeInfo;
+
+    // Per Matter 1.4 11.15.6, the RSSI attribute is not reportable, so its value is not populated in the cache via
+    // subscription reports. Therefore, we must read it on-demand.
+    // This context pointer is passed to the read attribute callback, which will be responsible for deleting it. However,
+    // if the ReadAttribute request fails to be sent, then we must delete it here.
+    auto rssiReadContext = new OnDemandReadContext(context, eventHandler, deviceId);
+
+    chip::Controller::ClusterBase cluster(exchangeMgr, sessionHandle, endpointId);
+
+    CHIP_ERROR error = cluster.ReadAttribute<TypeInfo>(
+        rssiReadContext,
+        [](void *context,
+           TypeInfo::DecodableArgType rssiValue) { /*read response success callback*/
+                                                   auto rssiReadContext = static_cast<OnDemandReadContext *>(context);
+                                                   const int8_t *nullableRssiValue =
+                                                       rssiValue.IsNull() ? nullptr : &rssiValue.Value();
+                                                   static_cast<WifiNetworkDiagnostics::EventHandler *>(
+                                                       rssiReadContext->eventHandler)
+                                                       ->RssiReadComplete(rssiReadContext->deviceId,
+                                                                          nullableRssiValue,
+                                                                          true,
+                                                                          rssiReadContext->baseReadContext);
+                                                   delete rssiReadContext;
+        },
+        [](void *context,
+           CHIP_ERROR error) { /*read response failure callback*/
+                               auto rssiReadContext = static_cast<OnDemandReadContext *>(context);
+                               icError("Failed to read RSSI attribute from device %s with error: %s",
+                                       rssiReadContext->deviceId.c_str(),
+                                       error.AsString());
+                               static_cast<WifiNetworkDiagnostics::EventHandler *>(rssiReadContext->eventHandler)
+                                   ->RssiReadComplete(
+                                       rssiReadContext->deviceId, nullptr, false, rssiReadContext->baseReadContext);
+                               delete rssiReadContext;
+        });
+
+    if (error != CHIP_NO_ERROR)
+    {
+        icError("Rssi ReadAttribute command failed with error: %s", error.AsString());
+        delete rssiReadContext;
+        return false;
     }
 
-    bool WifiNetworkDiagnostics::GetRssi(void *context,
-                                         const chip::Messaging::ExchangeManager &exchangeMgr,
-                                         const chip::SessionHandle &sessionHandle)
-    {
-        icDebug();
-
-        using namespace chip::app::Clusters::WiFiNetworkDiagnostics;
-        using TypeInfo = Attributes::Rssi::TypeInfo;
-
-        chip::app::ConcreteAttributePath path(endpointId,
-                                              chip::app::Clusters::WiFiNetworkDiagnostics::Id,
-                                              chip::app::Clusters::WiFiNetworkDiagnostics::Attributes::Rssi::Id);
-
-        chip::TLV::TLVReader reader;
-        CHIP_ERROR error = deviceDataCache->GetAttributeData(path, reader);
-        if (error != CHIP_NO_ERROR)
-        {
-            icError("Failed to get rssi attribute data: %s", error.AsString());
-            return false;
-        }
-
-        TypeInfo::DecodableType value;
-        error = chip::app::DataModel::Decode(reader, value);
-        if (error != CHIP_NO_ERROR)
-        {
-            icError("Failed to decode rssi attribute: %s", error.AsString());
-            return false;
-        }
-
-        int8_t *nullableValue = value.IsNull() ? nullptr : &value.Value();
-        static_cast<WifiNetworkDiagnostics::EventHandler *>(eventHandler)
-                    ->RssiReadComplete(deviceId, nullableValue, context);
-
-        return true;
-    };
-} // namespace barton
+    return true;
+};

--- a/core/deviceDrivers/matter/clusters/WifiNetworkDiagnostics.h
+++ b/core/deviceDrivers/matter/clusters/WifiNetworkDiagnostics.h
@@ -50,15 +50,14 @@ namespace barton
         class EventHandler : public MatterCluster::EventHandler
         {
         public:
-            virtual void RssiChanged(const std::string &deviceUuid, int8_t *rssi, void *asyncContext) {};
-            virtual void RssiReadComplete(const std::string &deviceUuid, int8_t *rssi, void *asyncContext) {};
+            virtual void RssiReadComplete(const std::string &deviceUuid,
+                                          const int8_t *rssi,
+                                          bool success,
+                                          void *asyncContext) {};
         };
 
         bool GetRssi(void *context,
-                     const chip::Messaging::ExchangeManager &exchangeMgr,
+                     chip::Messaging::ExchangeManager &exchangeMgr,
                      const chip::SessionHandle &sessionHandle);
-
-        void OnAttributeChanged(chip::app::ClusterStateCache *cache,
-                                const chip::app::ConcreteAttributePath &path) override;
     };
 } // namespace barton

--- a/core/src/subsystems/matter/MatterCommon.h
+++ b/core/src/subsystems/matter/MatterCommon.h
@@ -85,6 +85,18 @@ namespace barton
                 return chip::kUndefinedNodeId;
             }
 
+            /**
+             * Calculate link score for a Matter device, given an RSSI value in dBM (range -120 to 0).
+             * @return link score (range 0-100)
+             */
+            uint8_t calculateLinkScore(int8_t rssi);
+
+            /**
+             * Determine link quality string for a Matter device, given a link score value.
+             * Caller must free the result.
+             */
+            char *determineLinkQuality(uint8_t linkScore);
+
             struct SubscriptionIntervalSecs
             {
                 SubscriptionIntervalSecs(uint16_t floor, uint16_t ceiling) :


### PR DESCRIPTION
Add support for the wifi diagnostics cluster in the base Matter device driver and track the RSSI value for wifi devices. Calculate link score and link quality from the RSSI. Per requirements, link scores >45 are "good," 30-45 are "fair," and <30 are "poor."

Refs: BARTON-305