### PR TITLE
fix(matter): return software version string

### DIFF
--- a/core/src/subsystems/matter/providers/BartonDeviceInstanceInfoProvider.cpp
+++ b/core/src/subsystems/matter/providers/BartonDeviceInstanceInfoProvider.cpp
@@ -347,6 +347,15 @@ CHIP_ERROR BartonDeviceInstanceInfoProvider::GetHardwareVersionString(char *buf,
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR BartonDeviceInstanceInfoProvider::GetSoftwareVersionString(char *buf, size_t bufSize)
+{
+    // Because the software version string is also used internally by Matter for OTA purposes,
+    // we will return a compile-time constant defined in the Matter configuration.
+    VerifyOrReturnError(strlen(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING) < bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR BartonDeviceInstanceInfoProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan)
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)

--- a/core/src/subsystems/matter/providers/BartonDeviceInstanceInfoProvider.hpp
+++ b/core/src/subsystems/matter/providers/BartonDeviceInstanceInfoProvider.hpp
@@ -61,6 +61,7 @@ namespace barton {
         CHIP_ERROR GetManufacturingDate(uint16_t &year, uint8_t &month, uint8_t &day) override;
         CHIP_ERROR GetHardwareVersion(uint16_t &hardwareVersion) override;
         CHIP_ERROR GetHardwareVersionString(char *buf, size_t bufSize) override;
+        CHIP_ERROR GetSoftwareVersionString(char *buf, size_t bufSize) override;
         CHIP_ERROR GetRotatingDeviceIdUniqueId(chip::MutableByteSpan &uniqueIdSpan) override;
     };
 


### PR DESCRIPTION
The DeviceInstanceInfoProvider's GetSoftwareVersion method was not being overridden which resulted in a not implemented error and a read failure on the attribute in the basic information cluster. The software version is handled differently than the hardware version in the Matter SDK since it changes and is used by the OTA classes. For now, both the numerical and string versions used are provided at build time.