### PR TITLE
refactor(docker): use barton service directly in devcontainer compose model

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,10 @@
     "name": "Barton Ubuntu Development Environment",
     "initializeCommand": "docker/setupDockerEnv.sh",
     "dockerComposeFile": [
+        "../docker/compose.yaml",
         "../docker/compose.devcontainer.yaml"
     ],
-    "service": "devcontainer",
+    "service": "barton",
 
     // keep the local path of our tree the same within the container
     "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,16 +6,53 @@ ensures that the application runs the same way across different machines. This a
 simplifies the setup process, reduces compatibility issues, and streamlines the development
 workflow.
 
-Additionally, Barton uses Docker Compose to simplify the management of multi-container applications,
-ensuring a consistent development environment. The Compose setup consists of a base `compose.yaml`
-file, which defines the core services, and an extended `compose.devcontainer.yaml` that integrates
-with the Visual Studio Code devcontainer for streamlined development. This approach allows for easy
-dependency management, consistent local environments, and seamless collaboration across different
-development setups.
+## Compose File Layout
+
+Barton uses a layered Docker Compose model. A base `compose.yaml` defines the core `barton`
+service, and optional overlays add or override behavior:
+
+| File | Purpose |
+|---|---|
+| `compose.yaml` | Base service definition (`barton`), network, volumes |
+| `compose.devcontainer.yaml` | Overrides the `barton` service image/build for VS Code devcontainers (bakes the user into the image at build time) |
+| `compose.host-network.yaml` | Switches to host networking for direct device access (e.g., Thread border routers) |
+| `compose.observability.yaml` | Adds OTel Collector + Jaeger services and sets OTEL env vars on the `barton` service |
+
+All overlays operate on the same `barton` service from `compose.yaml`. They are combined by
+listing them in order -- either in the `dockerComposeFile` array in `.devcontainer/devcontainer.json`
+or via `-f` flags on the command line.
+
+### Devcontainer
+
+The devcontainer is configured in `.devcontainer/devcontainer.json` and composes:
+
+```
+compose.yaml → compose.devcontainer.yaml → compose.observability.yaml
+```
+
+### dockerw
+
+The `dockerw` script at the repo root is a convenience wrapper for `docker compose run`.
+It always includes `compose.yaml` as the base, and accepts flags to layer on overlays:
+
+| Flag | Effect |
+|---|---|
+| `-o` | Include `compose.observability.yaml` (OTel Collector + Jaeger) |
+| `-H` | Use host networking |
+| `-e <env>` | Pass extra environment variables |
+| `-d` | Mount development volumes |
+| `-n` | Disable TTY (non-interactive mode) |
+
+Example:
+
+```bash
+./dockerw -o bash          # with observability services
+./dockerw -H bash          # with host networking
+```
 
 ## Building
 
-To build the Barton image, simply run the `docker/build.sh` to create a Barton image.
+To build the Barton image, simply run `docker/build.sh` to create a Barton image.
 
 ## Editing the Image
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,6 @@ service, and optional overlays add or override behavior:
 | `compose.yaml` | Base service definition (`barton`), network, volumes |
 | `compose.devcontainer.yaml` | Overrides the `barton` service image/build for VS Code devcontainers (bakes the user into the image at build time) |
 | `compose.host-network.yaml` | Switches to host networking for direct device access (e.g., Thread border routers) |
-| `compose.observability.yaml` | Adds OTel Collector + Jaeger services and sets OTEL env vars on the `barton` service |
 
 All overlays operate on the same `barton` service from `compose.yaml`. They are combined by
 listing them in order -- either in the `dockerComposeFile` array in `.devcontainer/devcontainer.json`
@@ -27,7 +26,7 @@ or via `-f` flags on the command line.
 The devcontainer is configured in `.devcontainer/devcontainer.json` and composes:
 
 ```
-compose.yaml → compose.devcontainer.yaml → compose.observability.yaml
+compose.yaml → compose.devcontainer.yaml
 ```
 
 ### dockerw
@@ -37,7 +36,6 @@ It always includes `compose.yaml` as the base, and accepts flags to layer on ove
 
 | Flag | Effect |
 |---|---|
-| `-o` | Include `compose.observability.yaml` (OTel Collector + Jaeger) |
 | `-H` | Use host networking |
 | `-e <env>` | Pass extra environment variables |
 | `-d` | Mount development volumes |
@@ -46,7 +44,6 @@ It always includes `compose.yaml` as the base, and accepts flags to layer on ove
 Example:
 
 ```bash
-./dockerw -o bash          # with observability services
 ./dockerw -H bash          # with host networking
 ```
 

--- a/docker/compose.devcontainer.yaml
+++ b/docker/compose.devcontainer.yaml
@@ -25,21 +25,19 @@
 # Created by Kevin Funderburg on 09/20/2024
 #
 
-# This compose file is used to create the VSC devcontainer by extending the barton
-# service from the base compose.yaml file. It is not meant to be run directly.
+# Compose overlay for the VSC devcontainer. Meant to be combined with compose.yaml:
+#   docker compose -f compose.yaml -f compose.devcontainer.yaml ...
+#
+# It overrides the barton service's image/build so that the user is baked into
+# the image at build time (devcontainers require this -- the entrypoint.sh
+# approach used by dockerw does not work for VS Code remote containers).
 
 # Setting the name element to the user helps keep the container name easy to identify
-# by namespacing it with the user's name and workspace. Example: $BUILDER_USER-barton-$BARTON_WORKSPACE_ID-devcontainer-1
-name: $BUILDER_USER-barton-$BARTON_WORKSPACE_ID
+# by namespacing it with the user's name and workspace. Example: $BUILDER_USER-barton-$BARTON_WORKSPACE_ID-devcontainer
+name: $BUILDER_USER-barton-$BARTON_WORKSPACE_ID-devcontainer
 
 services:
-    devcontainer:
-        extends:
-            file: ./compose.yaml
-            service: barton
-        networks:
-            - barton-ip6net
-
+    barton:
         # devcontainers do not support creating a user at runtime like we do with the
         # `entrypoint.sh` script, so we need to override the base image with
         # Dockerfile.devcontainer file that bakes the user into the image.
@@ -53,9 +51,3 @@ services:
                 - BUILDER_UID=$BUILDER_UID
                 - IMAGE_REPO=$IMAGE_REPO
                 - IMAGE_TAG=$IMAGE_TAG
-
-networks:
-    barton-ip6net:
-        name: $BUILDER_USER-$BARTON_WORKSPACE_ID-barton-ip6net
-        # Indicate that the network is defined outside of this compose file
-        external: true

--- a/docker/compose.host-network.yaml
+++ b/docker/compose.host-network.yaml
@@ -35,6 +35,7 @@
 #     .devcontainer/devcontainer.json:
 #
 #       "dockerComposeFile": [
+#           "../docker/compose.yaml",
 #           "../docker/compose.devcontainer.yaml",
 #           "../docker/compose.host-network.yaml"
 #       ]
@@ -44,6 +45,6 @@
 #       when switching to host networking.
 
 services:
-    devcontainer:
+    barton:
         network_mode: host
         networks: !reset []


### PR DESCRIPTION
Remove the 'devcontainer' service that extended 'barton' via extends: and instead override the 'barton' service directly in compose.devcontainer.yaml. The base compose.yaml is now listed first in devcontainer.json's dockerComposeFile array.

- devcontainer.json: add compose.yaml as base, service -> barton, formatting
- compose.devcontainer.yaml: override barton directly, drop extends + network
- compose.host-network.yaml: devcontainer -> barton, update comment

(cherry picked from commit d4e306534b1d92f48ee94df5f2f0785cd65155f0)