### PR TITLE
chore: push release tag with deploy key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Generate Changelog
         run: cog changelog --at ${{ steps.release.outputs.version }} > CHANGELOG.md
 
-      # Correlates release with already uploaded tag. This action doesn't support deply keys, so we push the tag
+      # Correlates release with already uploaded tag. This action doesn't support deploy keys, so we push the tag
       # ourselves earlier.
       - name: Upload github release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,9 +49,14 @@ jobs:
         with:
           release: true
 
+      - name: Push tag via Git
+        run: git push origin ${{ steps.release.outputs.version }}
+
       - name: Generate Changelog
         run: cog changelog --at ${{ steps.release.outputs.version }} > CHANGELOG.md
 
+      # Correlates release with already uploaded tag. This action doesn't support deply keys, so we push the tag
+      # ourselves earlier.
       - name: Upload github release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Currently, the release workflow doesn't work with branch/tag protection rules. The reason being is we pushed the tag via the softprops/action-gh-release@v1 action, which used GITHUB_TOKEN and not our repository deploy key secret. This commit changes the release workflow to push the tag ourselves first (using the deploy secret) and then the action will simply generate the github release with the existing tag.