### PR TITLE
feat(sbmd): add script execution timeout for mquickjs engine

### DIFF
--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -268,6 +268,11 @@ bcore_int_option(NAME BCORE_MQUICKJS_MEMSIZE_BYTES
                DESCRIPTION "Size in bytes of the pre-allocated memory buffer for mquickjs."
                VALUE 1048576)
 
+bcore_int_option(NAME BCORE_SBMD_SCRIPT_TIMEOUT_MS
+               DEFINITION BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS
+               DESCRIPTION "Maximum execution time in milliseconds for SBMD mapper scripts."
+               VALUE 5000)
+
 message(STATUS "- - - - - - - - - - - - - - - - ")
 
 # Check removed/replaced options

--- a/core/deviceDrivers/matter/sbmd/mquickjs/MQuickJsRuntime.cpp
+++ b/core/deviceDrivers/matter/sbmd/mquickjs/MQuickJsRuntime.cpp
@@ -30,6 +30,7 @@
 
 #include "MQuickJsRuntime.h"
 
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -53,7 +54,7 @@ JSContext *MQuickJsRuntime::ctx = nullptr;
 std::mutex MQuickJsRuntime::mutex;
 bool MQuickJsRuntime::initialized = false;
 size_t MQuickJsRuntime::peakHeapUsed = 0;
-
+std::chrono::steady_clock::time_point MQuickJsRuntime::deadline {};
 namespace
 {
     /**
@@ -70,6 +71,32 @@ namespace
             return std::string(str);
         }
         return "unknown error";
+    }
+
+    /**
+     * Interrupt handler for script execution timeout.
+     *
+     * Called periodically by the mquickjs engine during bytecode execution.
+     * Returns non-zero to abort the running script when the deadline has passed.
+     * When no deadline is active (epoch value), always returns 0.
+     */
+    int ScriptInterruptHandler(JSContext * /*ctx*/, void * /*opaque*/)
+    {
+        auto currentDeadline = MQuickJsRuntime::GetDeadline();
+
+        // No deadline set, allow script to run uninterrupted
+        if (currentDeadline == std::chrono::steady_clock::time_point {})
+        {
+            return 0;
+        }
+
+        if (std::chrono::steady_clock::now() > currentDeadline)
+        {
+            icError("SBMD script execution timeout: script exceeded the configured time limit");
+            return 1;
+        }
+
+        return 0;
     }
 
 } // anonymous namespace
@@ -146,6 +173,11 @@ bool MQuickJsRuntime::Initialize(size_t memorySize)
     }
 
     initialized = true;
+
+    // Install the script execution timeout interrupt handler
+    JS_SetInterruptHandler(ctx, ScriptInterruptHandler);
+    icDebug("Script execution interrupt handler installed");
+
     {
         std::lock_guard<std::mutex> lock(mutex);
         LogMemoryUsage("post-init (context + stdlib + polyfills)", IC_LOG_DEBUG);
@@ -349,6 +381,21 @@ void MQuickJsRuntime::LogMemoryUsage(const char *label, logPriority priority, bo
                  usage.free_size,
                  usage.overhead);
     }
+}
+
+void MQuickJsRuntime::SetDeadline(std::chrono::steady_clock::time_point value)
+{
+    deadline = value;
+}
+
+void MQuickJsRuntime::ClearDeadline()
+{
+    deadline = std::chrono::steady_clock::time_point {};
+}
+
+std::chrono::steady_clock::time_point MQuickJsRuntime::GetDeadline()
+{
+    return deadline;
 }
 
 } // namespace barton

--- a/core/deviceDrivers/matter/sbmd/mquickjs/MQuickJsRuntime.h
+++ b/core/deviceDrivers/matter/sbmd/mquickjs/MQuickJsRuntime.h
@@ -133,15 +133,15 @@ namespace barton
         static void LogMemoryUsage(const char *label, logPriority priority, bool walkHeap = false);
 
         /**
-         * Set or clear the script execution deadline.
+         * Set the script execution deadline.
          *
-         * When a non-zero deadline is set, the interrupt handler will terminate
-         * any running script once steady_clock::now() exceeds the deadline.
-         * Pass a default-constructed time_point (epoch) to clear the deadline.
+         * When set, the interrupt handler will terminate any running script
+         * once steady_clock::now() exceeds the deadline. Call ClearDeadline()
+         * to disable timeout enforcement.
          *
          * Must be called while holding GetMutex().
          *
-         * @param deadline The absolute time point at which to interrupt, or epoch to disable
+         * @param deadline The absolute time point at which to interrupt
          */
         static void SetDeadline(std::chrono::steady_clock::time_point deadline);
 

--- a/core/deviceDrivers/matter/sbmd/mquickjs/MQuickJsRuntime.h
+++ b/core/deviceDrivers/matter/sbmd/mquickjs/MQuickJsRuntime.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
@@ -131,6 +132,33 @@ namespace barton
          */
         static void LogMemoryUsage(const char *label, logPriority priority, bool walkHeap = false);
 
+        /**
+         * Set or clear the script execution deadline.
+         *
+         * When a non-zero deadline is set, the interrupt handler will terminate
+         * any running script once steady_clock::now() exceeds the deadline.
+         * Pass a default-constructed time_point (epoch) to clear the deadline.
+         *
+         * Must be called while holding GetMutex().
+         *
+         * @param deadline The absolute time point at which to interrupt, or epoch to disable
+         */
+        static void SetDeadline(std::chrono::steady_clock::time_point deadline);
+
+        /**
+         * Clear the script execution deadline, disabling timeout enforcement.
+         *
+         * Must be called while holding GetMutex().
+         */
+        static void ClearDeadline();
+
+        /**
+         * Get the current script execution deadline.
+         *
+         * @return The current deadline, or epoch if no deadline is active
+         */
+        static std::chrono::steady_clock::time_point GetDeadline();
+
     private:
         static uint8_t *memBuffer;
         static size_t memSize;
@@ -138,6 +166,7 @@ namespace barton
         static std::mutex mutex;
         static bool initialized;
         static size_t peakHeapUsed;
+        static std::chrono::steady_clock::time_point deadline;
     };
 
 } // namespace barton

--- a/core/deviceDrivers/matter/sbmd/mquickjs/SbmdScriptImpl.cpp
+++ b/core/deviceDrivers/matter/sbmd/mquickjs/SbmdScriptImpl.cpp
@@ -271,7 +271,16 @@ bool SbmdScriptImpl::ExecuteScript(const std::string &script,
     JS_PushArg(ctx, jsonArg);
     JS_PushArg(ctx, func);
     JS_PushArg(ctx, JS_NULL);
+
+    // Arm the execution timeout before calling into JS
+    MQuickJsRuntime::SetDeadline(std::chrono::steady_clock::now() +
+                                 std::chrono::milliseconds(BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS));
+
     JSValue scriptResult = JS_Call(ctx, 1);
+
+    // Disarm the deadline immediately after JS returns
+    MQuickJsRuntime::ClearDeadline();
+
     if (JS_IsException(scriptResult))
     {
         std::string err = GetExceptionString(ctx);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -209,6 +209,11 @@ if (BCORE_MATTER)
 
     if (TARGET testSbmdScript)
         target_link_libraries(testSbmdScript bCoreConfig)
+        # Use a short timeout for tests so they don't wait 5 seconds.
+        # The -U removes the definition from bCoreConfig before -D redefines it.
+        target_compile_options(testSbmdScript PRIVATE
+            -UBARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS
+            -DBARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS=100)
     endif()
 
     if (BUILD_TESTING)

--- a/core/test/src/SbmdScriptTest.cpp
+++ b/core/test/src/SbmdScriptTest.cpp
@@ -1161,6 +1161,156 @@ namespace
         EXPECT_TRUE(MQuickJsRuntime::IsInitialized());
     }
 
+    //--------------------------------------------------------------------------
+    // Script execution timeout tests (mquickjs-specific)
+    //
+    // These tests verify that the interrupt handler terminates runaway scripts
+    // and that the context remains usable afterward.
+    //--------------------------------------------------------------------------
+
+    class SbmdScriptTimeoutTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override { MQuickJsRuntime::Shutdown(); }
+
+        void TearDown() override { MQuickJsRuntime::Shutdown(); }
+    };
+
+    // An infinite loop script must be terminated by the interrupt handler
+    TEST_F(SbmdScriptTimeoutTest, InfiniteLoopTerminatedByTimeout)
+    {
+        ASSERT_TRUE(MQuickJsRuntime::Initialize(1048576));
+
+        JSContext *ctx = MQuickJsRuntime::GetSharedContext();
+        ASSERT_NE(ctx, nullptr);
+        ASSERT_TRUE(SbmdUtilsLoader::LoadBundle(ctx));
+
+        auto script = SbmdScriptImpl::Create("timeout-test-device");
+        ASSERT_NE(script, nullptr);
+
+        SbmdAttribute attr;
+        attr.clusterId = 6;
+        attr.attributeId = 0;
+        attr.name = "timeoutTest";
+        attr.type = "bool";
+
+        std::string infiniteScript = "while(true) {} return {output: 'never'};";
+        ASSERT_TRUE(script->AddAttributeReadMapper(attr, infiniteScript));
+
+        // Create a simple TLV boolean
+        uint8_t tlvBuffer[32];
+        chip::TLV::TLVWriter writer;
+        writer.Init(tlvBuffer, sizeof(tlvBuffer));
+        writer.PutBoolean(chip::TLV::AnonymousTag(), true);
+        writer.Finalize();
+
+        chip::TLV::TLVReader reader;
+        reader.Init(tlvBuffer, writer.GetLengthWritten());
+        reader.Next();
+
+        std::string outValue;
+        // Must return false (script interrupted), not hang forever
+        bool result = script->MapAttributeRead(attr, reader, outValue);
+        EXPECT_FALSE(result);
+    }
+
+    // A normal fast script completes successfully with timeout enabled
+    TEST_F(SbmdScriptTimeoutTest, NormalScriptCompletesWithTimeoutEnabled)
+    {
+        ASSERT_TRUE(MQuickJsRuntime::Initialize(1048576));
+
+        JSContext *ctx = MQuickJsRuntime::GetSharedContext();
+        ASSERT_NE(ctx, nullptr);
+        ASSERT_TRUE(SbmdUtilsLoader::LoadBundle(ctx));
+
+        auto script = SbmdScriptImpl::Create("timeout-normal-device");
+        ASSERT_NE(script, nullptr);
+
+        SbmdAttribute attr;
+        attr.clusterId = 6;
+        attr.attributeId = 0;
+        attr.name = "normalTest";
+        attr.type = "bool";
+
+        std::string normalScript =
+            "var val = SbmdUtils.Tlv.decode(sbmdReadArgs.tlvBase64); return {output: val ? 'true' : 'false'};";
+        ASSERT_TRUE(script->AddAttributeReadMapper(attr, normalScript));
+
+        uint8_t tlvBuffer[32];
+        chip::TLV::TLVWriter writer;
+        writer.Init(tlvBuffer, sizeof(tlvBuffer));
+        writer.PutBoolean(chip::TLV::AnonymousTag(), true);
+        writer.Finalize();
+
+        chip::TLV::TLVReader reader;
+        reader.Init(tlvBuffer, writer.GetLengthWritten());
+        reader.Next();
+
+        std::string outValue;
+        ASSERT_TRUE(script->MapAttributeRead(attr, reader, outValue));
+        EXPECT_EQ(outValue, "true");
+    }
+
+    // After a timeout, the context must remain usable for subsequent scripts
+    TEST_F(SbmdScriptTimeoutTest, ContextUsableAfterTimeout)
+    {
+        ASSERT_TRUE(MQuickJsRuntime::Initialize(1048576));
+
+        JSContext *ctx = MQuickJsRuntime::GetSharedContext();
+        ASSERT_NE(ctx, nullptr);
+        ASSERT_TRUE(SbmdUtilsLoader::LoadBundle(ctx));
+
+        auto script = SbmdScriptImpl::Create("timeout-recovery-device");
+        ASSERT_NE(script, nullptr);
+
+        SbmdAttribute badAttr;
+        badAttr.clusterId = 6;
+        badAttr.attributeId = 0;
+        badAttr.name = "badScript";
+        badAttr.type = "bool";
+
+        SbmdAttribute goodAttr;
+        goodAttr.clusterId = 6;
+        goodAttr.attributeId = 1;
+        goodAttr.name = "goodScript";
+        goodAttr.type = "bool";
+
+        std::string infiniteScript = "while(true) {} return {output: 'never'};";
+        std::string normalScript =
+            "var val = SbmdUtils.Tlv.decode(sbmdReadArgs.tlvBase64); return {output: val ? 'true' : 'false'};";
+
+        ASSERT_TRUE(script->AddAttributeReadMapper(badAttr, infiniteScript));
+        ASSERT_TRUE(script->AddAttributeReadMapper(goodAttr, normalScript));
+
+        // Create TLV boolean for both calls
+        uint8_t tlvBuffer[32];
+        chip::TLV::TLVWriter writer;
+        writer.Init(tlvBuffer, sizeof(tlvBuffer));
+        writer.PutBoolean(chip::TLV::AnonymousTag(), false);
+        writer.Finalize();
+
+        // First: run the infinite loop script — should time out
+        {
+            chip::TLV::TLVReader reader;
+            reader.Init(tlvBuffer, writer.GetLengthWritten());
+            reader.Next();
+
+            std::string outValue;
+            EXPECT_FALSE(script->MapAttributeRead(badAttr, reader, outValue));
+        }
+
+        // Second: run a normal script — should succeed, proving context is OK
+        {
+            chip::TLV::TLVReader reader;
+            reader.Init(tlvBuffer, writer.GetLengthWritten());
+            reader.Next();
+
+            std::string outValue;
+            ASSERT_TRUE(script->MapAttributeRead(goodAttr, reader, outValue));
+            EXPECT_EQ(outValue, "false");
+        }
+    }
+
 #endif // BCORE_USE_MQUICKJS
 
 } // namespace

--- a/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/design.md
+++ b/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/design.md
@@ -1,0 +1,111 @@
+## Context
+
+SBMD mapper scripts run inside a shared mquickjs singleton context. All script executions (across all devices and all mapper types) are serialized through a single mutex (`MQuickJsRuntime::GetMutex()`). The current execution path in `SbmdScriptImpl::ExecuteScript` compiles the script via `JS_Eval`, then calls it via `JS_Call`, with no mechanism to abort a running script.
+
+```
+Current execution flow (no timeout):
+
+  MapAttributeRead / MapWrite / MapExecute / MapEvent
+       │
+       ▼
+  lock(MQuickJsRuntime::GetMutex())
+       │
+       ▼
+  ExecuteScript(script, argName, jsonArg, outJson)
+       │
+       ├── JS_Eval(wrappedScript)   ← compile phase (fast, bounded)
+       │
+       ├── JS_Call(ctx, 1)          ← execution phase (UNBOUNDED)
+       │                               while(true){} blocks here forever
+       │                               mutex held the entire time
+       ▼
+  return result
+```
+
+The mquickjs engine provides `JS_SetInterruptHandler(ctx, handler)` which installs a callback invoked periodically during JS bytecode execution. If the handler returns non-zero, the engine throws an exception and aborts the current script. This is the standard mechanism for implementing execution timeouts in QuickJS-family engines.
+
+
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent any single SBMD script execution from blocking the service indefinitely.
+- Provide a configurable timeout with a sensible default.
+- Fail gracefully through existing error paths (no crashes, no leaked state).
+- Log clear diagnostics when a script is terminated or rejected.
+
+**Non-Goals:**
+- Protecting against cross-script pollution of JS globals/builtins.
+- Validating script output (cluster/command IDs).
+- Changes to the quickjs backend.
+- Per-execution context isolation.
+
+## Decisions
+
+### Decision 1: Use mquickjs interrupt handler with opcode-count-based timeout
+
+**Choice**: Install a `JS_SetInterruptHandler` callback on the shared context. Track a deadline (`std::chrono::steady_clock`) set before each `JS_Call`. The handler checks the clock and returns non-zero if the deadline has passed.
+
+**Why not a separate watchdog thread?** The interrupt handler is called from within the JS engine's bytecode interpreter loop — it naturally fires during long-running scripts without requiring a separate thread, timer, or signal. The mutex is already held during execution, so a separate thread couldn't safely interact with the context anyway.
+
+**Why steady_clock?** It's monotonic (immune to wall-clock adjustments) and available in C++17.
+
+**Alternatives considered:**
+- **POSIX signals (SIGALRM)**: Unsafe with mutexes, not portable, difficult to target the right thread.
+- **Separate watchdog thread**: Would need to coordinate with the mutex holder; adds complexity for no benefit since the interrupt handler is purpose-built for this.
+
+### Decision 2: Timeout is set per-ExecuteScript call, not globally
+
+**Choice**: Set the deadline immediately before `JS_Call` in `ExecuteScript` and clear it after via `ClearDeadline()`. Use a static variable (safe because the mutex serializes all access). The timeout duration is the compile-time `BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS`.
+
+**Rationale**: The interrupt handler is global to the context, but we only want it active during script execution, not during `SbmdUtilsLoader::LoadBundle` or other internal JS operations. A static deadline variable that is only set during `ExecuteScript` achieves this — when no deadline is set (zero/default), the handler returns 0 (continue).
+
+### Decision 3: Timeout value as a CMake build-time option
+
+**Choice**: Add `BCORE_SBMD_SCRIPT_TIMEOUT_MS` as a `bcore_int_option` in `config/cmake/options.cmake` with a default of 5000ms (5 seconds). Compiled into the binary as `BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS`.
+
+**Rationale**: Consistent with existing pattern (`BCORE_MQUICKJS_MEMSIZE_BYTES`). 5 seconds is generous for scripts that should complete in microseconds — any script taking more than 5 seconds is certainly misbehaving.
+
+### Decision 4: Interrupt handler installed once at Initialize, deadline controls activation
+
+**Choice**: Install the interrupt handler in `MQuickJsRuntime::Initialize()` and leave it installed for the lifetime of the context. The handler checks a static `deadline` variable — when it's zero (default, no active script), the handler returns 0 immediately (no interrupt). `ExecuteScript` sets the deadline before `JS_Call` and clears it after.
+
+```
+Proposed execution flow:
+
+  MQuickJsRuntime::Initialize()
+       │
+       ▼
+  JS_SetInterruptHandler(ctx, ScriptInterruptHandler)
+       │   (installed once, checks static deadline)
+
+  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+
+  ExecuteScript(script, argName, jsonArg, outJson)
+       │
+       ├── JS_Eval(wrappedScript)
+       │
+       ├── SetDeadline(now + BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS)  ← arm
+       ├── JS_Call(ctx, 1)                 ← engine periodically calls handler
+       │       │                              handler: return (now > deadline) ? 1 : 0
+       │       └── (if interrupted, JS_Call returns exception)
+       ├── ClearDeadline()                 ← disarm
+       ▼
+  return result
+```
+
+**Why not install/remove per call?** `JS_SetInterruptHandler` may have non-trivial overhead in mquickjs. Installing once and using a flag is simpler and avoids any edge cases with the handler being partially installed during a call.
+
+## Risks / Trade-offs
+
+**[Risk: Interrupt handler granularity]** → The interrupt handler is called at opcode boundaries, not on a precise timer. A script blocked in a native C function (e.g., a hypothetical long-running `SbmdUtils` call) would not be interrupted until the C function returns to JS. **Mitigation**: All current `SbmdUtils` native functions are fast (TLV encode/decode, base64). This is acceptable.
+
+**[Risk: Timeout too aggressive for slow platforms]** → A device running on very constrained hardware might hit the timeout on legitimate scripts. **Mitigation**: The timeout is a build-time configurable option (`BCORE_SBMD_SCRIPT_TIMEOUT_MS`). Deployers can increase it. The 5s default is already 1000x longer than any expected script execution.
+
+**[Risk: State after timeout]** → After an interrupt, the mquickjs context may have partially-constructed objects on the heap. **Mitigation**: The interrupt causes a JS exception, which is caught by the existing `JS_IsException` check after `JS_Call`. GC will clean up unreachable objects. The context remains usable for subsequent scripts.
+
+**[Backward compatibility]** → No public API changes. The timeout and size limit are new internal behaviors with generous defaults. Existing `.sbmd` specs are unaffected — all current scripts are small and fast.
+
+**[Thread safety]** → The static deadline variable is safe because all access to the mquickjs context (and therefore all calls to `ExecuteScript`) is serialized through `MQuickJsRuntime::GetMutex()`. The interrupt handler itself is called from within `JS_Call`, which runs under the same mutex.
+
+**[GObject API implications]** → None. This change is entirely internal to the SBMD script execution layer and does not affect the public GObject API, signals, or properties.

--- a/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/proposal.md
+++ b/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+SBMD mapper scripts execute inside a shared mquickjs context protected by a single mutex. If any script enters an infinite loop or performs a computationally unbounded operation, the mutex is held indefinitely, blocking all SBMD device operations across the entire service with no recovery short of process restart. The mquickjs engine exposes `JS_SetInterruptHandler()` for exactly this purpose, but it is not currently wired in. This is a denial-of-service vulnerability that should be addressed before SBMD specs are accepted from broader sources.
+
+## What Changes
+
+- Add a configurable script execution timeout enforced via the mquickjs interrupt handler mechanism (`JS_SetInterruptHandler`).
+- Scripts that exceed the timeout will be terminated and the operation will return failure (existing error path).
+
+## Non-goals
+
+- Protecting `SbmdUtils` or JS builtins from cross-script mutation (separate concern, separate change).
+- Output validation of cluster/command IDs returned by scripts (separate concern).
+- Spec file integrity or signature verification.
+- Per-execution context isolation.
+- Changes to the quickjs backend (mquickjs is the go-forward engine).
+
+## Capabilities
+
+### New Capabilities
+- `sbmd-script-execution-limits`: Script execution timeout via interrupt handler.
+
+### Modified Capabilities
+- `sbmd-system`: The existing SBMD system spec gains new requirements for script execution timeout behavior.
+
+## Impact
+
+- **Core layer**: `MQuickJsRuntime` (interrupt handler setup), `SbmdScriptImpl` (timeout tracking in `ExecuteScript`).
+- **Build system**: One new CMake integer option for timeout.
+- **CMake flags**: `BCORE_MATTER` (existing), `BCORE_MATTER_SBMD_JS_ENGINE` (existing, mquickjs path only).
+- **Testing**: New unit tests in `SbmdScriptTest.cpp` for timeout and size limit behavior.
+- **No API changes**: This is entirely internal to the SBMD script execution layer, invisible to the public C API.

--- a/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/specs/sbmd-script-execution-limits/spec.md
+++ b/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/specs/sbmd-script-execution-limits/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Script execution timeout
+The mquickjs runtime SHALL enforce a maximum execution time for SBMD mapper scripts. The timeout SHALL be implemented using the mquickjs `JS_SetInterruptHandler` mechanism. When a script exceeds the configured timeout, the interrupt handler SHALL cause the engine to throw an exception, terminating the script.
+
+#### Scenario: Script completes within timeout
+- **WHEN** a mapper script executes and completes within the configured timeout period
+- **THEN** the script SHALL return its result normally and the interrupt handler SHALL not interfere
+
+#### Scenario: Infinite loop terminated by timeout
+- **WHEN** a mapper script contains an infinite loop (e.g., `while(true){}`)
+- **THEN** the interrupt handler SHALL terminate the script after the configured timeout and `ExecuteScript` SHALL return `false`
+
+#### Scenario: Long-running computation terminated
+- **WHEN** a mapper script performs a computation that exceeds the configured timeout
+- **THEN** the interrupt handler SHALL terminate the script and the operation SHALL fail gracefully without crashing
+
+#### Scenario: Timeout produces diagnostic logging
+- **WHEN** a script is terminated due to timeout
+- **THEN** the system SHALL log an error message indicating the script was interrupted due to exceeding the execution time limit
+
+#### Scenario: Context remains usable after timeout
+- **WHEN** a script is terminated due to timeout
+- **THEN** subsequent script executions on other devices or resources SHALL succeed normally
+
+### Requirement: Script execution timeout configuration
+The script execution timeout SHALL be configurable via the `BCORE_SBMD_SCRIPT_TIMEOUT_MS` CMake integer option with a default value of 5000 (5 seconds). The value SHALL be compiled into the binary as `BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS`.
+
+#### Scenario: Default timeout value
+- **WHEN** `BCORE_SBMD_SCRIPT_TIMEOUT_MS` is not explicitly set
+- **THEN** the default timeout SHALL be 5000 milliseconds
+
+#### Scenario: Custom timeout value
+- **WHEN** `BCORE_SBMD_SCRIPT_TIMEOUT_MS=10000` is set at CMake configuration time
+- **THEN** scripts SHALL be allowed up to 10 seconds of execution time
+
+### Requirement: Interrupt handler lifecycle
+The interrupt handler SHALL be installed once during `MQuickJsRuntime::Initialize()` and remain installed for the lifetime of the context. The handler SHALL use a static deadline variable to determine whether a timeout is active. `ExecuteScript` SHALL arm the deadline via `SetDeadline()` before `JS_Call` and disarm it via `ClearDeadline()` after. When no deadline is active (cleared), the handler SHALL return 0 (do not interrupt).
+
+#### Scenario: Handler installed at initialization
+- **WHEN** `MQuickJsRuntime::Initialize()` is called
+- **THEN** `JS_SetInterruptHandler` SHALL be called on the shared context with the timeout handler
+
+#### Scenario: Handler inactive outside script execution
+- **WHEN** the interrupt handler is called outside of `ExecuteScript` (e.g., during `SbmdUtilsLoader::LoadBundle`)
+- **THEN** the handler SHALL return 0, allowing execution to continue uninterrupted
+

--- a/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/specs/sbmd-system/spec.md
+++ b/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/specs/sbmd-system/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: mquickjs memory configuration
+When using the mquickjs engine, the system SHALL support configuring the pre-allocated memory buffer size via the `BCORE_MQUICKJS_MEMSIZE_BYTES` CMake integer option (default: 1048576 bytes = 1 MB). The mquickjs engine uses a fixed-size, non-growing memory buffer. Additionally, the system SHALL support `BCORE_SBMD_SCRIPT_TIMEOUT_MS` (default: 5000) for script execution timeout.
+
+#### Scenario: Custom mquickjs memory size
+- **WHEN** `BCORE_MQUICKJS_MEMSIZE_BYTES=4194304` is set
+- **THEN** the mquickjs engine SHALL allocate a 4 MB memory buffer
+
+#### Scenario: Script timeout configuration
+- **WHEN** `BCORE_SBMD_SCRIPT_TIMEOUT_MS=10000` is set
+- **THEN** the mquickjs engine SHALL allow scripts up to 10 seconds of execution time before interrupting

--- a/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/tasks.md
+++ b/openspec/changes/archive/2026-04-10-sbmd-script-execution-timeout/tasks.md
@@ -1,0 +1,13 @@
+## 1. Build System Configuration
+
+- [x] 1.1 Add `BCORE_SBMD_SCRIPT_TIMEOUT_MS` integer option (default 5000) to `config/cmake/options.cmake` with definition `BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS`
+
+## 2. Script Execution Timeout
+
+- [x] 2.1 Implement interrupt handler in `MQuickJsRuntime`: add static deadline variable, implement `ScriptInterruptHandler` callback that checks `steady_clock::now()` against deadline, wire `JS_SetInterruptHandler` into `Initialize()`
+- [x] 2.2 Integrate timeout into `SbmdScriptImpl::ExecuteScript`: set deadline before `JS_Call`, clear after, log error on timeout
+- [x] 2.3 Add unit tests for timeout: infinite loop script terminates, normal script completes, context usable after timeout
+
+## 3. Verification
+
+- [x] 3.1 Build and run full unit test suite to confirm no regressions

--- a/openspec/specs/sbmd-script-execution-limits/spec.md
+++ b/openspec/specs/sbmd-script-execution-limits/spec.md
@@ -1,0 +1,44 @@
+### Requirement: Script execution timeout
+The mquickjs runtime SHALL enforce a maximum execution time for SBMD mapper scripts. The timeout SHALL be implemented using the mquickjs `JS_SetInterruptHandler` mechanism. When a script exceeds the configured timeout, the interrupt handler SHALL cause the engine to throw an exception, terminating the script.
+
+#### Scenario: Script completes within timeout
+- **WHEN** a mapper script executes and completes within the configured timeout period
+- **THEN** the script SHALL return its result normally and the interrupt handler SHALL not interfere
+
+#### Scenario: Infinite loop terminated by timeout
+- **WHEN** a mapper script contains an infinite loop (e.g., `while(true){}`)
+- **THEN** the interrupt handler SHALL terminate the script after the configured timeout and `ExecuteScript` SHALL return `false`
+
+#### Scenario: Long-running computation terminated
+- **WHEN** a mapper script performs a computation that exceeds the configured timeout
+- **THEN** the interrupt handler SHALL terminate the script and the operation SHALL fail gracefully without crashing
+
+#### Scenario: Timeout produces diagnostic logging
+- **WHEN** a script is terminated due to timeout
+- **THEN** the system SHALL log an error message indicating the script was interrupted due to exceeding the execution time limit
+
+#### Scenario: Context remains usable after timeout
+- **WHEN** a script is terminated due to timeout
+- **THEN** subsequent script executions on other devices or resources SHALL succeed normally
+
+### Requirement: Script execution timeout configuration
+The script execution timeout SHALL be configurable via the `BCORE_SBMD_SCRIPT_TIMEOUT_MS` CMake integer option with a default value of 5000 (5 seconds). The value SHALL be compiled into the binary as `BARTON_CONFIG_SBMD_SCRIPT_TIMEOUT_MS`.
+
+#### Scenario: Default timeout value
+- **WHEN** `BCORE_SBMD_SCRIPT_TIMEOUT_MS` is not explicitly set
+- **THEN** the default timeout SHALL be 5000 milliseconds
+
+#### Scenario: Custom timeout value
+- **WHEN** `BCORE_SBMD_SCRIPT_TIMEOUT_MS=10000` is set at CMake configuration time
+- **THEN** scripts SHALL be allowed up to 10 seconds of execution time
+
+### Requirement: Interrupt handler lifecycle
+The interrupt handler SHALL be installed once during `MQuickJsRuntime::Initialize()` and remain installed for the lifetime of the context. The handler SHALL use a static deadline variable to determine whether a timeout is active. `ExecuteScript` SHALL arm the deadline via `SetDeadline()` before `JS_Call` and disarm it via `ClearDeadline()` after. When no deadline is active (cleared), the handler SHALL return 0 (do not interrupt).
+
+#### Scenario: Handler installed at initialization
+- **WHEN** `MQuickJsRuntime::Initialize()` is called
+- **THEN** `JS_SetInterruptHandler` SHALL be called on the shared context with the timeout handler
+
+#### Scenario: Handler inactive outside script execution
+- **WHEN** the interrupt handler is called outside of `ExecuteScript` (e.g., during `SbmdUtilsLoader::LoadBundle`)
+- **THEN** the handler SHALL return 0, allowing execution to continue uninterrupted

--- a/openspec/specs/sbmd-system/spec.md
+++ b/openspec/specs/sbmd-system/spec.md
@@ -141,11 +141,15 @@ All devices SHALL share a single runtime singleton context regardless of engine 
 - **THEN** the script instance SHALL serialize access via its internal mutex
 
 ### Requirement: mquickjs memory configuration
-When using the mquickjs engine, the system SHALL support configuring the pre-allocated memory buffer size via the `BCORE_MQUICKJS_MEMSIZE_BYTES` CMake integer option (default: 1048576 bytes = 1 MB). The mquickjs engine uses a fixed-size, non-growing memory buffer.
+When using the mquickjs engine, the system SHALL support configuring the pre-allocated memory buffer size via the `BCORE_MQUICKJS_MEMSIZE_BYTES` CMake integer option (default: 1048576 bytes = 1 MB). The mquickjs engine uses a fixed-size, non-growing memory buffer. Additionally, the system SHALL support `BCORE_SBMD_SCRIPT_TIMEOUT_MS` (default: 5000) for script execution timeout.
 
 #### Scenario: Custom mquickjs memory size
 - **WHEN** `BCORE_MQUICKJS_MEMSIZE_BYTES=4194304` is set
 - **THEN** the mquickjs engine SHALL allocate a 4 MB memory buffer
+
+#### Scenario: Script timeout configuration
+- **WHEN** `BCORE_SBMD_SCRIPT_TIMEOUT_MS=10000` is set
+- **THEN** the mquickjs engine SHALL allow scripts up to 10 seconds of execution time before interrupting
 
 ### Requirement: SbmdUtils built-in library
 The system SHALL provide a built-in JavaScript library `SbmdUtils` (loaded into every QuickJS context) with: `SbmdUtils.Tlv.decode(base64)` for Matter TLV decoding, `SbmdUtils.Tlv.decodeStruct(base64)` for struct TLV decoding, `SbmdUtils.Tlv.encode(value, type)` for TLV encoding, `SbmdUtils.Tlv.encodeStruct(obj, schema)` for struct encoding, `SbmdUtils.Tlv.emptyStruct()` for empty struct TLV, `SbmdUtils.Response.write(clusterId, attributeId, tlvBase64, options?)` for write operation construction, `SbmdUtils.Response.invoke(clusterId, commandId, tlvBase64, opts)` for invoke operation construction, `SbmdUtils.Base64` for base64 encode/decode, and `SbmdUtils.TLV_TYPE` with TLV type constants.


### PR DESCRIPTION
Add a configurable timeout that terminates long-running or infinite-loop SBMD mapper scripts using the mquickjs JS_SetInterruptHandler API.

Implementation:
- CMake option BCORE_SBMD_SCRIPT_TIMEOUT_MS (default 5000ms)
- Deadline armed before JS_Call, cleared after via SetDeadline()/ClearDeadline()
- Interrupt handler checks steady_clock deadline on each engine tick
- Context remains usable after a timeout

Tests:
- InfiniteLoopTerminatedByTimeout
- NormalScriptCompletesWithTimeoutEnabled
- ContextUsableAfterTimeout

OpenSpec: archive sbmd-script-execution-timeout, sync specs

Refs: BARTON-346