### PR TITLE
fix: Handle bad inputs in Sbmd.Base64.decode()

### DIFF
--- a/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-utils.js
+++ b/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-utils.js
@@ -204,7 +204,8 @@
 
                 if (c0 === -1 || c1 === -1 || c2 === -1 || c3 === -1)
                 {
-                    throw new Error('Invalid Base64 character at position ' + i);
+                    var badIndex = c0 === -1 ? i : c1 === -1 ? i + 1 : c2 === -1 ? i + 2 : i + 3;
+                    throw new Error('Invalid Base64 character at index ' + badIndex + ': \'' + base64[badIndex] + '\'');
                 }
 
                 bytes.push((c0 << 2) | (c1 >> 4));

--- a/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-utils.js
+++ b/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-utils.js
@@ -202,6 +202,11 @@
                 var c2 = base64[i + 2] === '=' ? 0 : this.chars.indexOf(base64[i + 2]);
                 var c3 = base64[i + 3] === '=' ? 0 : this.chars.indexOf(base64[i + 3]);
 
+                if (c0 === -1 || c1 === -1 || c2 === -1 || c3 === -1)
+                {
+                    throw new Error('Invalid Base64 character at position ' + i);
+                }
+
                 bytes.push((c0 << 2) | (c1 >> 4));
                 if (base64[i + 2] !== '=')
                 {

--- a/core/test/src/SbmdScriptTest.cpp
+++ b/core/test/src/SbmdScriptTest.cpp
@@ -1006,8 +1006,8 @@ namespace
         attr.name = "onOff";
         attr.type = "bool";
 
-        // '!!!!' is a valid-length (4-char) quartet with all-invalid Base64 characters.
-        std::string mapperScript = "var val = SbmdUtils.Tlv.decode('!!!!'); return {output: 'unreachable'};";
+        // 'CQ!!' is a valid-length (4-char) quartet with an invalid '!' at index 2 and 3.
+        std::string mapperScript = "var val = SbmdUtils.Tlv.decode('CQ!!'); return {output: 'unreachable'};";
 
         ASSERT_TRUE(script->AddAttributeReadMapper(attr, mapperScript));
 

--- a/core/test/src/SbmdScriptTest.cpp
+++ b/core/test/src/SbmdScriptTest.cpp
@@ -1006,7 +1006,8 @@ namespace
         attr.name = "onOff";
         attr.type = "bool";
 
-        std::string mapperScript = "var val = SbmdUtils.Tlv.decode('!!!invalid!!!'); return {output: 'unreachable'};";
+        // '!!!!' is a valid-length (4-char) quartet with all-invalid Base64 characters.
+        std::string mapperScript = "var val = SbmdUtils.Tlv.decode('!!!!'); return {output: 'unreachable'};";
 
         ASSERT_TRUE(script->AddAttributeReadMapper(attr, mapperScript));
 
@@ -1033,8 +1034,9 @@ namespace
         attr.name = "onOff";
         attr.type = "bool";
 
+        // 'AA!A' is a valid-length (4-char) quartet with an invalid '!' at index 2.
         std::string mapperScript =
-            "var bytes = SbmdUtils.Base64.decode('!!!bad!!!'); return {output: bytes.length.toString()};";
+            "var bytes = SbmdUtils.Base64.decode('AA!A'); return {output: bytes.length.toString()};";
 
         ASSERT_TRUE(script->AddAttributeReadMapper(attr, mapperScript));
 

--- a/core/test/src/SbmdScriptTest.cpp
+++ b/core/test/src/SbmdScriptTest.cpp
@@ -994,6 +994,65 @@ namespace
     }
 
     //--------------------------------------------------------------------------
+    // Input validation tests — invalid Base64 input
+    //--------------------------------------------------------------------------
+
+    // Test: SbmdUtils.Tlv.decode throws on invalid Base64 characters
+    TEST_F(SbmdScriptTest, TlvDecodeInvalidBase64Exception)
+    {
+        SbmdAttribute attr;
+        attr.clusterId = 0x0006;
+        attr.attributeId = 0x0000;
+        attr.name = "onOff";
+        attr.type = "bool";
+
+        std::string mapperScript = "var val = SbmdUtils.Tlv.decode('!!!invalid!!!'); return {output: 'unreachable'};";
+
+        ASSERT_TRUE(script->AddAttributeReadMapper(attr, mapperScript));
+
+        uint8_t tlvBuffer[32];
+        chip::TLV::TLVWriter writer;
+        writer.Init(tlvBuffer, sizeof(tlvBuffer));
+        writer.PutBoolean(chip::TLV::AnonymousTag(), true);
+        writer.Finalize();
+
+        chip::TLV::TLVReader reader;
+        reader.Init(tlvBuffer, writer.GetLengthWritten());
+        reader.Next();
+
+        std::string outValue;
+        EXPECT_FALSE(script->MapAttributeRead(attr, reader, outValue));
+    }
+
+    // Test: SbmdUtils.Base64.decode throws on invalid Base64 characters
+    TEST_F(SbmdScriptTest, Base64DecodeInvalidBase64Exception)
+    {
+        SbmdAttribute attr;
+        attr.clusterId = 0x0006;
+        attr.attributeId = 0x0000;
+        attr.name = "onOff";
+        attr.type = "bool";
+
+        std::string mapperScript =
+            "var bytes = SbmdUtils.Base64.decode('!!!bad!!!'); return {output: bytes.length.toString()};";
+
+        ASSERT_TRUE(script->AddAttributeReadMapper(attr, mapperScript));
+
+        uint8_t tlvBuffer[32];
+        chip::TLV::TLVWriter writer;
+        writer.Init(tlvBuffer, sizeof(tlvBuffer));
+        writer.PutBoolean(chip::TLV::AnonymousTag(), true);
+        writer.Finalize();
+
+        chip::TLV::TLVReader reader;
+        reader.Init(tlvBuffer, writer.GetLengthWritten());
+        reader.Next();
+
+        std::string outValue;
+        EXPECT_FALSE(script->MapAttributeRead(attr, reader, outValue));
+    }
+
+    //--------------------------------------------------------------------------
     // Out-of-memory handling tests (mquickjs-specific)
     //
     // These tests artificially restrict the mquickjs arena to verify that

--- a/docs/SBMD.md
+++ b/docs/SBMD.md
@@ -1061,3 +1061,4 @@ Common error causes:
 - Missing `output` field in return value
 - Type mismatches in TLV conversion
 - Undefined variables or properties
+- Invalid Base64 input passed to `SbmdUtils.Tlv.decode()` or `SbmdUtils.Base64.decode()`

--- a/openspec/specs/sbmd-system/spec.md
+++ b/openspec/specs/sbmd-system/spec.md
@@ -162,6 +162,10 @@ The system SHALL provide a built-in JavaScript library `SbmdUtils` (loaded into 
 - **WHEN** `SbmdUtils.Response.invoke(6, 1, tlvBase64)` is called
 - **THEN** it SHALL return `{invoke: {clusterId: 6, commandId: 1, tlvBase64: <value>}}`
 
+#### Scenario: Decode invalid Base64 input
+- **WHEN** `SbmdUtils.Tlv.decode(base64)` or `SbmdUtils.Base64.decode(base64)` is called with a string containing characters outside the Base64 alphabet (not A–Z, a–z, 0–9, `+`, `/`, or `=`)
+- **THEN** it SHALL throw a JavaScript `Error` describing the invalid input
+
 ### Requirement: Script context variables
 SBMD scripts SHALL receive context via global JavaScript variables: `sbmdReadArgs` (with `tlvBase64`, `endpointId`, `deviceUuid`, `clusterFeatureMaps`, `clusterId`, `attributeId`, `attributeName`, `attributeType`), `sbmdWriteArgs` (with `input`, `resourceId`, `endpointId`, `deviceUuid`, `clusterFeatureMaps`), `sbmdExecuteArgs`, `sbmdEventArgs`, and `sbmdCommandResponseArgs`.
 


### PR DESCRIPTION
Check whether or not indexOf() returns -1 for invalid characters. If so, throw an Error.
Add unit tests to test this behavior, TlvDecodeInvalidBase64Exception() and Base64DecodeInvalidBase64Exception().
Update docs.

Refs: BARTON-360