### PR TITLE
feat(ref): reloadDatabase command support

### DIFF
--- a/api/c/public/barton-core-client.h
+++ b/api/c/public/barton-core-client.h
@@ -476,6 +476,16 @@ gboolean b_core_client_execute_resource(BCoreClient *self, const gchar *uri, con
 gboolean b_core_client_write_resource(BCoreClient *self, const gchar *uri, const gchar *resourceValue);
 
 /**
+ * b_core_client_reload_database
+ * @self: the BCoreClient instance.
+ *
+ * @brief Reload the database.
+ *
+ * Returns: gboolean - true if the database was reloaded successfully, false otherwise.
+ */
+gboolean b_core_client_reload_database(BCoreClient *self);
+
+/**
  * b_core_client_get_devices_by_subsystem
  * @self: the BCoreClient instance.
  * @subsystem: the subsystem to search for.

--- a/api/c/src/barton-core-client.c
+++ b/api/c/src/barton-core-client.c
@@ -454,6 +454,13 @@ gboolean b_core_client_execute_resource(BCoreClient *self,
     return deviceServiceExecuteResource(uri, payload, response) ? TRUE : FALSE;
 }
 
+gboolean b_core_client_reload_database(BCoreClient *self)
+{
+    g_return_val_if_fail(self != NULL, FALSE);
+
+    return deviceServiceReloadDatabase() ? TRUE : FALSE;
+}
+
 gboolean b_core_client_remove_device(BCoreClient *self, const gchar *uuid)
 {
     g_return_val_if_fail(self != NULL, FALSE);

--- a/api/c/test/CMakeLists.txt
+++ b/api/c/test/CMakeLists.txt
@@ -258,6 +258,7 @@ bcore_add_cmocka_test(
         zhalTest
         zigbeeSubsystemPerformEnergyScan
         deviceServiceRestoreConfig
+        deviceServiceReloadDatabase
     LINK_LIBRARIES BartonCoreStatic
     INCLUDES ${PRIVATE_API_INCLUDES} ${PROJECT_SOURCE_DIR}/core/src
 )

--- a/api/c/test/barton-core-client-test.c
+++ b/api/c/test/barton-core-client-test.c
@@ -223,6 +223,7 @@ icLinkedList *__wrap_zigbeeSubsystemPerformEnergyScan(const uint8_t *channelsToS
                                                       uint32_t scanDurationMillis,
                                                       uint32_t numScans);
 bool __wrap_deviceServiceRestoreConfig(const char *tempRestoreDir);
+bool __wrap_deviceServiceReloadDatabase(void);
 
 // Mock Signal Handlers
 #define DECLARE_MOCK_EVENT_HANDLER(eventType)                                                                          \
@@ -1448,6 +1449,29 @@ static void test_b_core_client_remove_device(void **state)
 
     bool result3 = b_core_client_remove_device(client, id);
     assert_true(result3);
+}
+
+static void test_b_core_client_reload_database(void **state)
+{
+    BCoreClient *client = *state;
+
+    // NULL client
+    bool result1 = b_core_client_reload_database(NULL);
+    assert_false(result1);
+
+    // valid client, success
+    expect_function_call(__wrap_deviceServiceReloadDatabase);
+    will_return(__wrap_deviceServiceReloadDatabase, true);
+
+    bool result2 = b_core_client_reload_database(client);
+    assert_true(result2);
+
+    // valid client, failure
+    expect_function_call(__wrap_deviceServiceReloadDatabase);
+    will_return(__wrap_deviceServiceReloadDatabase, false);
+
+    bool result3 = b_core_client_reload_database(client);
+    assert_false(result3);
 }
 
 static void test_b_core_client_get_system_property(void **state)
@@ -5379,6 +5403,12 @@ bool __wrap_deviceServiceRestoreConfig(const char *tempRestoreDir)
     return (bool) mock();
 }
 
+bool __wrap_deviceServiceReloadDatabase(void)
+{
+    function_called();
+    return (bool) mock();
+}
+
 #define DEFINE_MOCK_EVENT_HANDLER(eventType)                                                                           \
     static void mockHandle##eventType(GObject *source, BCore##eventType *event)                               \
     {                                                                                                                  \
@@ -5435,6 +5465,7 @@ int main(int argc, const char **argv)
         cmocka_unit_test(test_b_core_client_write_resource),
         cmocka_unit_test(test_b_core_client_execute_resource),
         cmocka_unit_test(test_b_core_client_remove_device),
+        cmocka_unit_test(test_b_core_client_reload_database),
         cmocka_unit_test(test_b_core_client_get_system_property),
         cmocka_unit_test(test_b_core_client_set_system_property),
         cmocka_unit_test(test_b_core_client_remove_endpoint_by_id),

--- a/reference/src/barton-core-reference-app.c
+++ b/reference/src/barton-core-reference-app.c
@@ -60,8 +60,6 @@ static gchar *wifi_password = NULL;
 static gchar *storage_dir = NULL;
 static gchar *sbmd_dirs = NULL;
 
-static bool showAdvanced = false;
-
 static GList *categories = NULL;
 
 static GOptionEntry entries[] = {
@@ -93,7 +91,7 @@ static void showInteractiveHelp(bool isInteractive)
     for (GList *it = categories; it != NULL; it = it->next)
     {
         Category *category = (Category *) it->data;
-        categoryPrint(category, isInteractive, showAdvanced);
+        categoryPrint(category, isInteractive);
     }
 }
 
@@ -130,7 +128,7 @@ static bool handleInteractiveCommand(BCoreClient *client, char **args, int numAr
                 Command *command = findCommand(args[1]);
                 if (command != NULL)
                 {
-                    commandPrintUsage(command, true, showAdvanced);
+                    commandPrintUsage(command, true);
                 }
                 else
                 {

--- a/reference/src/category.c
+++ b/reference/src/category.c
@@ -36,7 +36,6 @@ struct _Category
 {
     gchar *name;
     gchar *description;
-    bool isAdvanced;
     GList *commands; // less efficient, but we want ordered.
 };
 
@@ -61,13 +60,6 @@ void categoryDestroy(Category *category)
     free(category->description);
     g_list_free_full(category->commands, commandEntryFreeFunc);
     free(category);
-}
-
-void categorySetAdvanced(Category *category)
-{
-    g_return_if_fail(category != NULL);
-
-    category->isAdvanced = true;
 }
 
 void categoryAddCommand(Category *category, Command *command)
@@ -150,18 +142,15 @@ GList *categoryGetCompletions(const Category *category, const gchar *buf)
     return result;
 }
 
-void categoryPrint(const Category *category, bool isInteractive, bool showAdvanced)
+void categoryPrint(const Category *category, bool isInteractive)
 {
     g_return_if_fail(category != NULL);
 
-    if (category->isAdvanced == false || showAdvanced == true)
+    emitOutput("%s:\n", category->name);
+    for (GList *it = category->commands; it != NULL; it = it->next)
     {
-        emitOutput("%s:\n", category->name);
-        for (GList *it = category->commands; it != NULL; it = it->next)
-        {
-            Command *command = (Command *) it->data;
-            commandPrintUsage(command, isInteractive, showAdvanced);
-        }
+        Command *command = (Command *) it->data;
+        commandPrintUsage(command, isInteractive);
     }
 }
 

--- a/reference/src/category.c
+++ b/reference/src/category.c
@@ -147,6 +147,7 @@ void categoryPrint(const Category *category, bool isInteractive)
     g_return_if_fail(category != NULL);
 
     emitOutput("%s:\n", category->name);
+
     for (GList *it = category->commands; it != NULL; it = it->next)
     {
         Command *command = (Command *) it->data;

--- a/reference/src/category.h
+++ b/reference/src/category.h
@@ -47,13 +47,6 @@ Category *categoryCreate(const gchar *name, const gchar *description);
 void categoryDestroy(Category *category);
 
 /**
- * Mark this Category as advanced (only showing when advanced mode is enabled).
- *
- * @param category
- */
-void categorySetAdvanced(Category *category);
-
-/**
  * Add a Command instance to this Category.
  *
  * @param category
@@ -83,6 +76,5 @@ GList *categoryGetCompletions(const Category *category, const gchar *buf);
  *
  * @param category
  * @param isInteractive true if we are in interactive mode
- * @param showAdvanced true if we are in advanced mode
  */
-void categoryPrint(const Category *category, bool isInteractive, bool showAdvanced);
+void categoryPrint(const Category *category, bool isInteractive);

--- a/reference/src/command.c
+++ b/reference/src/command.c
@@ -37,7 +37,6 @@ struct _Command
     gchar *shortInteractiveName;
     gchar *argUsage;
     gchar *help;
-    bool isAdvanced;
     gint minArgs;
     gint maxArgs; // -1 for unlimited
     commandExecFunc func;
@@ -102,14 +101,6 @@ gchar *commandGetShortName(const Command *command)
     return NULL;
 }
 
-void commandSetAdvanced(Command *command)
-{
-    if (command != NULL)
-    {
-        command->isAdvanced = true;
-    }
-}
-
 bool commandExecute(BCoreClient *client, const Command *command, gint argc, gchar **argv)
 {
     bool result = false;
@@ -137,9 +128,9 @@ void commandAddExample(Command *command, const gchar *example)
     }
 }
 
-void commandPrintUsage(const Command *command, bool isInteractive, bool showAdvanced)
+void commandPrintUsage(const Command *command, bool isInteractive)
 {
-    if (command != NULL && (command->isAdvanced == false || showAdvanced == true))
+    if (command != NULL)
     {
         if (isInteractive)
         {

--- a/reference/src/command.h
+++ b/reference/src/command.h
@@ -79,13 +79,6 @@ gchar *commandGetName(const Command *command);
 gchar *commandGetShortName(const Command *command);
 
 /**
- * Mark this Command as advanced (it will only appear to the user if advanced mode is enabled)
- *
- * @param command
- */
-void commandSetAdvanced(Command *command);
-
-/**
  * Execute a Command.
  *
  * @param client
@@ -108,6 +101,5 @@ void commandAddExample(Command *command, const gchar *example);
  *
  * @param command
  * @param isInteractive true if we are in interactive mode
- * @param showAdvanced true if we are in advanced mode
  */
-void commandPrintUsage(const Command *command, bool isInteractive, bool showAdvanced);
+void commandPrintUsage(const Command *command, bool isInteractive);

--- a/reference/src/coreCategory.c
+++ b/reference/src/coreCategory.c
@@ -1178,7 +1178,6 @@ Category *buildCoreCategory(void)
     // remove devices (advanced)
     command = commandCreate(
         "removeDevices", NULL, "[device class]", "Remove devices (all or by class)", 0, 1, removeDevicesFunc);
-    commandSetAdvanced(command);
     categoryAddCommand(cat, command);
 
     //system prop read
@@ -1224,7 +1223,6 @@ Category *buildCoreCategory(void)
                             0,
                             0,
                             reloadDatabaseFunc);
-    commandSetAdvanced(command);
     categoryAddCommand(cat, command);
 
     return cat;

--- a/reference/src/coreCategory.c
+++ b/reference/src/coreCategory.c
@@ -1175,7 +1175,7 @@ Category *buildCoreCategory(void)
     command = commandCreate("removeEndpoint", "re", "<uri>", "Remove an endpoint by uri", 1, 1, removeEndpointFunc);
     categoryAddCommand(cat, command);
 
-    // remove devices (advanced)
+    // remove devices
     command = commandCreate(
         "removeDevices", NULL, "[device class]", "Remove devices (all or by class)", 0, 1, removeDevicesFunc);
     categoryAddCommand(cat, command);
@@ -1215,7 +1215,7 @@ Category *buildCoreCategory(void)
     commandAddExample(command, "ddl clearbypass");
     categoryAddCommand(cat, command);
 
-    // reload database (advanced)
+    // reload database
     command = commandCreate("reloadDatabase",
                             NULL,
                             NULL,

--- a/reference/src/coreCategory.c
+++ b/reference/src/coreCategory.c
@@ -1061,6 +1061,19 @@ static bool ddlFunc(BCoreClient *client, gint argc, gchar **argv)
     return result;
 }
 
+static bool reloadDatabaseFunc(BCoreClient *client, gint argc, gchar **argv)
+{
+    (void) argc; // unused
+    (void) argv; // unused
+
+    bool result = b_core_client_reload_database(client);
+    if (!result)
+    {
+        emitError("Failed to reload database\n");
+    }
+    return result;
+}
+
 Category *buildCoreCategory(void)
 {
     Category *cat = categoryCreate("Core", "Core/standard commands");
@@ -1199,6 +1212,17 @@ Category *buildCoreCategory(void)
     commandAddExample(command, "ddl process");
     commandAddExample(command, "ddl bypass");
     commandAddExample(command, "ddl clearbypass");
+    categoryAddCommand(cat, command);
+
+    //reload database (advanced)
+    command = commandCreate("reloadDatabase",
+                            NULL,
+                            NULL,
+                            "Instruct device service to reload its device database",
+                            0,
+                            0,
+                            reloadDatabaseFunc);
+    commandSetAdvanced(command);
     categoryAddCommand(cat, command);
 
     return cat;

--- a/reference/src/coreCategory.c
+++ b/reference/src/coreCategory.c
@@ -1067,10 +1067,12 @@ static bool reloadDatabaseFunc(BCoreClient *client, gint argc, gchar **argv)
     (void) argv; // unused
 
     bool result = b_core_client_reload_database(client);
+
     if (!result)
     {
         emitError("Failed to reload database\n");
     }
+
     return result;
 }
 
@@ -1214,7 +1216,7 @@ Category *buildCoreCategory(void)
     commandAddExample(command, "ddl clearbypass");
     categoryAddCommand(cat, command);
 
-    //reload database (advanced)
+    // reload database (advanced)
     command = commandCreate("reloadDatabase",
                             NULL,
                             NULL,


### PR DESCRIPTION
Adds the command to reloadDatabase reference app's cli. Also removes the concept of advance commands from barton's reference app. Now it will show all the commands.

Refs: BARTON-110