### PR TITLE
fix(ref): validate device exists before opening commissioning window

### DIFF
--- a/reference/src/command.c
+++ b/reference/src/command.c
@@ -120,6 +120,7 @@ bool commandExecute(BCoreClient *client, const Command *command, gint argc, gcha
         {
             /* Validate argv: not NULL when argc > 0, and each argv[i] is non-NULL */
             bool argsValid = (argc == 0 || argv != NULL);
+
             if (argsValid && argc > 0)
             {
                 for (gint i = 0; i < argc && argsValid; i++)

--- a/reference/src/command.c
+++ b/reference/src/command.c
@@ -118,7 +118,17 @@ bool commandExecute(BCoreClient *client, const Command *command, gint argc, gcha
     {
         if (argc >= command->minArgs && (command->maxArgs == -1 || argc <= command->maxArgs))
         {
-            if (argc == 0 || argv != NULL)
+            /* Validate argv: not NULL when argc > 0, and each argv[i] is non-NULL */
+            bool argsValid = (argc == 0 || argv != NULL);
+            if (argsValid && argc > 0)
+            {
+                for (gint i = 0; i < argc && argsValid; i++)
+                {
+                    argsValid = (argv[i] != NULL);
+                }
+            }
+
+            if (argsValid)
             {
                 result = command->func(client, argc, argv);
             }

--- a/reference/src/command.c
+++ b/reference/src/command.c
@@ -118,7 +118,14 @@ bool commandExecute(BCoreClient *client, const Command *command, gint argc, gcha
     {
         if (argc >= command->minArgs && (command->maxArgs == -1 || argc <= command->maxArgs))
         {
-            result = command->func(client, argc, argv);
+            if (argc == 0 || argv != NULL)
+            {
+                result = command->func(client, argc, argv);
+            }
+            else
+            {
+                emitError("Invalid args\n");
+            }
         }
         else
         {

--- a/reference/src/command.h
+++ b/reference/src/command.h
@@ -88,6 +88,10 @@ void commandSetAdvanced(Command *command);
 /**
  * Execute a Command.
  *
+ * Validates that argc is within the command's minArgs and maxArgs bounds,
+ * and that argv is not NULL when argc > 0. Arguments are validated before
+ * the command's function is executed, ensuring consistency across all commands.
+ *
  * @param client
  * @param command
  * @param argc

--- a/reference/src/command.h
+++ b/reference/src/command.h
@@ -89,8 +89,10 @@ void commandSetAdvanced(Command *command);
  * Execute a Command.
  *
  * Validates that argc is within the command's minArgs and maxArgs bounds,
- * and that argv is not NULL when argc > 0. Arguments are validated before
- * the command's function is executed, ensuring consistency across all commands.
+ * and that argv is not NULL when argc > 0. Additionally validates that each
+ * individual argv[i] is non-NULL for i in [0, argc). Arguments are validated
+ * before the command's function is executed, ensuring consistency across all
+ * commands.
  *
  * @param client
  * @param command

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -91,10 +91,11 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
     bool rc = false;
 
     /* Parse and validate the node ID.
+     * Accept decimal or hex (0x prefix) format.
      * Treat nodeId == 0 as local.
      * Otherwise, verify the device exists after normalizing the ID. */
     char *endptr = NULL;
-    unsigned long long nodeId = g_ascii_strtoull(argv[0], &endptr, 16);
+    unsigned long long nodeId = g_ascii_strtoull(argv[0], &endptr, 0);
 
     if (endptr == argv[0] || *endptr != '\0')
     {
@@ -172,6 +173,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
 static bool setWifiCredsFunc(BCoreClient *client, gint argc, gchar **argv)
 {
     b_reference_network_credentials_provider_set_wifi_network_credentials(argv[0], argv[1]);
+    return true;
 }
 
 Category *buildMatterCategory(void)

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -89,12 +89,9 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
 {
     bool rc = false;
 
-    /* Parse and validate the node ID.
-     * Accept decimal or hex (0x prefix) format.
-     * Treat nodeId == 0 as local.
-     * Otherwise, verify the device exists after normalizing the ID. */
+    /* Parse and validate the node ID as hexadecimal*/
     char *endptr = NULL;
-    guint64 nodeId = g_ascii_strtoull(argv[0], &endptr, 0);
+    guint64 nodeId = g_ascii_strtoull(argv[0], &endptr, 16);
 
     if (endptr == argv[0] || *endptr != '\0')
     {
@@ -102,14 +99,16 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
         return false;
     }
 
+    /* Convert the validated nodeId to zero-padded hex string format */
+    g_autofree gchar *nodeIdStr = g_strdup_printf("%016llx", nodeId);
+
     if (nodeId != 0)
     {
         /* Verify device exists by checking device lookup with zero-padded hex format.
          * NOTE: This lookup assumes Matter node IDs are used as device IDs.
          * If the internal mapping between Matter node IDs and Barton device IDs
          * changes, this lookup method may no longer be reliable. */
-        g_autofree gchar *nodeIdHex = g_strdup_printf("%016llx", nodeId);
-        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, nodeIdHex);
+        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, nodeIdStr);
 
         if (device == NULL)
         {
@@ -134,7 +133,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
     }
 
     g_autoptr(BCoreCommissioningInfo) commissioningInfo =
-        b_core_client_open_commissioning_window(client, argv[0], timeoutSeconds);
+        b_core_client_open_commissioning_window(client, nodeIdStr, timeoutSeconds);
 
     if (commissioningInfo == NULL)
     {

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -32,7 +32,6 @@
 #include "barton-core-reference-io.h"
 #include "reference-network-credentials-provider.h"
 #include <stdio.h>
-#include <string.h>
 
 static bool commissionDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 {

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -94,13 +94,14 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
      * Treat nodeId == 0 as local.
      * Otherwise, verify the device exists after normalizing the ID. */
     char *endptr = NULL;
-    unsigned long long nodeId = g_ascii_strtoull(argv[0], &endptr, 0);
+    guint64 nodeId = g_ascii_strtoull(argv[0], &endptr, 0);
 
     if (endptr == argv[0] || *endptr != '\0')
     {
         emitError("Invalid node id '%s'\n", argv[0]);
         return false;
     }
+
     if (nodeId != 0)
     {
         /* Verify device exists by checking device lookup with zero-padded hex format.
@@ -109,6 +110,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
          * changes, this lookup method may no longer be reliable. */
         g_autofree gchar *nodeIdHex = g_strdup_printf("%016llx", nodeId);
         g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, nodeIdHex);
+
         if (device == NULL)
         {
             emitError("No device with node id '%s' found\n", argv[0]);
@@ -120,7 +122,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
     if (argc == 2)
     {
         char *endptr = NULL;
-        unsigned long long timeout = g_ascii_strtoull(argv[1], &endptr, 10);
+        guint64 timeout = g_ascii_strtoull(argv[1], &endptr, 10);
 
         if (endptr == argv[1] || *endptr != '\0' || timeout > G_MAXUINT16)
         {
@@ -131,8 +133,6 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
         timeoutSeconds = (guint16) timeout;
     }
 
-    /* Pass original argv[0] to downstream parsing (stringToUint64 uses base 0).
-     * Bare zero-padded hex like "0000000000001234" would be misinterpreted as octal. */
     g_autoptr(BCoreCommissioningInfo) commissioningInfo =
         b_core_client_open_commissioning_window(client, argv[0], timeoutSeconds);
 
@@ -172,6 +172,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
 static bool setWifiCredsFunc(BCoreClient *client, gint argc, gchar **argv)
 {
     b_reference_network_credentials_provider_set_wifi_network_credentials(argv[0], argv[1]);
+
     return true;
 }
 

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -36,10 +36,6 @@
 
 static bool commissionDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 {
-    g_return_val_if_fail(argc == 1, false);
-    g_return_val_if_fail(argv != NULL, false);
-    g_return_val_if_fail(argv[0] != NULL, false);
-
     bool rc = true;
 
     g_autoptr(GError) error = NULL;
@@ -65,10 +61,6 @@ static bool commissionDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 
 static bool addMatterDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 {
-    g_return_val_if_fail(argc == 1, false);
-    g_return_val_if_fail(argv != NULL, false);
-    g_return_val_if_fail(argv[0] != NULL, false);
-
     uint64_t nodeId = g_ascii_strtoull(argv[0], NULL, 10);
 
     bool rc = true;
@@ -96,41 +88,33 @@ static bool addMatterDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 
 static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv)
 {
-    g_return_val_if_fail(argc >= 0 && argc <= 2, false);
-    g_return_val_if_fail(argc == 0 || argv != NULL, false);
-    g_return_val_if_fail(argc < 1 || argv[0] != NULL, false);
-    g_return_val_if_fail(argc < 2 || argv[1] != NULL, false);
-
     bool rc = false;
 
-    /* If a target device id was provided, parse and validate it.
+    /* Parse and validate the node ID.
      * Treat nodeId == 0 as local.
      * Otherwise, verify the device exists after normalizing the ID. */
-    if (argc >= 1)
+    char *endptr = NULL;
+    unsigned long long nodeId = g_ascii_strtoull(argv[0], &endptr, 16);
+
+    if (endptr == argv[0] || *endptr != '\0')
     {
-        char *endptr = NULL;
-        unsigned long long nodeId = g_ascii_strtoull(argv[0], &endptr, 16);
+        emitError("Invalid node id '%s'\n", argv[0]);
+        return false;
+    }
+    g_autofree gchar *nodeIdArg = NULL;
+    if (nodeId != 0)
+    {
+        nodeIdArg = g_strdup_printf("%016llx", nodeId);
 
-        if (endptr == argv[0] || *endptr != '\0')
+        /* Verify device exists.
+         * NOTE: This lookup assumes Matter node IDs are used as device IDs.
+         * If the internal mapping between Matter node IDs and Barton device IDs
+         * changes, this lookup method may no longer be reliable. */
+        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, nodeIdArg);
+        if (device == NULL)
         {
-            emitError("Invalid node id '%s'\n", argv[0]);
+            emitError("No device with node id '%s' found\n", argv[0]);
             return false;
-        }
-
-        /* If not local (nodeId != 0), verify device exists */
-        if (nodeId != 0)
-        {
-            g_autofree gchar *normalizedId =
-                g_strdup_printf("%016llx", nodeId);
-
-            g_autoptr(BCoreDevice) device =
-                b_core_client_get_device_by_id(client, normalizedId);
-
-            if (device == NULL)
-            {
-                emitError("No device with node id '%s' found\n", argv[0]);
-                return false;
-            }
         }
     }
 
@@ -150,10 +134,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
     }
 
     g_autoptr(BCoreCommissioningInfo) commissioningInfo =
-        b_core_client_open_commissioning_window(
-            client,
-            (argc >= 1 ? argv[0] : NULL),
-            timeoutSeconds);
+        b_core_client_open_commissioning_window(client, nodeIdArg, timeoutSeconds);
 
     if (commissioningInfo == NULL)
     {
@@ -178,12 +159,9 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
         }
         else
         {
-            const gchar *manualCodeOutput = manualCode != NULL ? manualCode : "";
-            const gchar *qrCodeOutput = qrCode != NULL ? qrCode : "";
             emitOutput("Commissioning window opened:\n");
-            emitOutput("\tManual code: %s\n", manualCodeOutput);
-            emitOutput("\tQR code: %s\n", qrCodeOutput);
-
+            emitOutput("\tManual code: %s\n", manualCode != NULL ? manualCode : "");
+            emitOutput("\tQR code: %s\n", qrCode != NULL ? qrCode : "");
             rc = true;
         }
     }
@@ -193,11 +171,6 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
 
 static bool setWifiCredsFunc(BCoreClient *client, gint argc, gchar **argv)
 {
-    g_return_val_if_fail(argc == 2, false);
-    g_return_val_if_fail(argv != NULL, false);
-    g_return_val_if_fail(argv[0] != NULL, false);
-    g_return_val_if_fail(argv[1] != NULL, false);
-
     b_reference_network_credentials_provider_set_wifi_network_credentials(argv[0], argv[1]);
 }
 

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -101,16 +101,14 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
         emitError("Invalid node id '%s'\n", argv[0]);
         return false;
     }
-    g_autofree gchar *nodeIdArg = NULL;
     if (nodeId != 0)
     {
-        nodeIdArg = g_strdup_printf("%016llx", nodeId);
-
-        /* Verify device exists.
+        /* Verify device exists by checking device lookup with zero-padded hex format.
          * NOTE: This lookup assumes Matter node IDs are used as device IDs.
          * If the internal mapping between Matter node IDs and Barton device IDs
          * changes, this lookup method may no longer be reliable. */
-        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, nodeIdArg);
+        g_autofree gchar *nodeIdHex = g_strdup_printf("%016llx", nodeId);
+        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, nodeIdHex);
         if (device == NULL)
         {
             emitError("No device with node id '%s' found\n", argv[0]);
@@ -133,8 +131,10 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
         timeoutSeconds = (guint16) timeout;
     }
 
+    /* Pass original argv[0] to downstream parsing (stringToUint64 uses base 0).
+     * Bare zero-padded hex like "0000000000001234" would be misinterpreted as octal. */
     g_autoptr(BCoreCommissioningInfo) commissioningInfo =
-        b_core_client_open_commissioning_window(client, nodeIdArg, timeoutSeconds);
+        b_core_client_open_commissioning_window(client, argv[0], timeoutSeconds);
 
     if (commissioningInfo == NULL)
     {

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -96,11 +96,16 @@ static bool addMatterDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 
 static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv)
 {
+    g_return_val_if_fail(argc >= 0 && argc <= 2, false);
+    g_return_val_if_fail(argc == 0 || argv != NULL, false);
+    g_return_val_if_fail(argc < 1 || argv[0] != NULL, false);
+    g_return_val_if_fail(argc < 2 || argv[1] != NULL, false);
+
     bool rc = false;
 
     /* If a target device id was provided and it's not the local ("0"), verify
      * the device exists before attempting to open its commissioning window. */
-    if (argc >= 1 && argv[0] != NULL && strcmp(argv[0], "0") != 0)
+    if (argc >= 1 && strcmp(argv[0], "0") != 0)
     {
         g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, argv[0]);
         if (device == NULL)
@@ -118,6 +123,8 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
 
     BCoreCommissioningInfo *commissioningInfo =
         b_core_client_open_commissioning_window(client, (argc >= 1 ? argv[0] : NULL), timeoutSeconds);
+
+    g_autoptr(BCoreCommissioningInfo) autoCommissioningInfo = commissioningInfo;
 
     if (commissioningInfo == NULL)
     {
@@ -142,9 +149,11 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
         }
         else
         {
+            const gchar *manualCodeOutput = manualCode != NULL ? manualCode : "";
+            const gchar *qrCodeOutput = qrCode != NULL ? qrCode : "";
             emitOutput("Commissioning window opened:\n");
-            emitOutput("\tManual code: %s\n", manualCode);
-            emitOutput("\tQR code: %s\n", qrCode);
+            emitOutput("\tManual code: %s\n", manualCodeOutput);
+            emitOutput("\tQR code: %s\n", qrCodeOutput);
 
             rc = true;
         }

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -104,13 +104,17 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
     bool rc = false;
 
     /* If a target device id was provided and it's not the local ("0"), verify
-     * the device exists before attempting to open its commissioning window. */
+     * the device exists before attempting to open its commissioning window.
+     * Normalize the device ID by zero-padding it to 16 hex characters to ensure
+     * it matches the stored Matter device UUID format. */
     if (argc >= 1 && strcmp(argv[0], "0") != 0)
     {
-        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, argv[0]);
+        g_autofree gchar *normalizedId = g_strdup_printf("%016llx",
+            (unsigned long long) g_ascii_strtoull(argv[0], NULL, 16));
+        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, normalizedId);
         if (device == NULL)
         {
-            emitError("No device with id '%s' found\n", argv[0]);
+            emitError("No device with node id '%s' found\n", argv[0]);
             return false;
         }
     }

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -32,6 +32,7 @@
 #include "barton-core-reference-io.h"
 #include "reference-network-credentials-provider.h"
 #include <stdio.h>
+#include <string.h>
 
 static bool commissionDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 {
@@ -95,8 +96,19 @@ static bool addMatterDeviceFunc(BCoreClient *client, gint argc, gchar **argv)
 
 static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv)
 {
-    (void) argc; // unused
     bool rc = false;
+
+    /* If a target device id was provided and it's not the local ("0"), verify
+     * the device exists before attempting to open its commissioning window. */
+    if (argc >= 1 && argv[0] != NULL && strcmp(argv[0], "0") != 0)
+    {
+        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, argv[0]);
+        if (device == NULL)
+        {
+            emitError("No device with id '%s' found\n", argv[0]);
+            return false;
+        }
+    }
 
     guint16 timeoutSeconds = 0; // let device service pick the default
     if (argc == 2)
@@ -105,7 +117,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
     }
 
     BCoreCommissioningInfo *commissioningInfo =
-        b_core_client_open_commissioning_window(client, argv[0], timeoutSeconds);
+        b_core_client_open_commissioning_window(client, (argc >= 1 ? argv[0] : NULL), timeoutSeconds);
 
     if (commissioningInfo == NULL)
     {
@@ -113,7 +125,7 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
     }
     else
     {
-        // print the manual and qr codes to stdout.  First get them from the object properties
+        /* print the manual and qr codes to stdout. First get them from the object properties */
         g_autofree gchar *manualCode = NULL;
         g_autofree gchar *qrCode = NULL;
         g_object_get(
@@ -124,11 +136,18 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
             &qrCode,
             NULL);
 
-        emitOutput("Commissioning window opened:\n");
-        emitOutput("\tManual code: %s\n", manualCode);
-        emitOutput("\tQR code: %s\n", qrCode);
+        if ((manualCode == NULL || manualCode[0] == '\0') && (qrCode == NULL || qrCode[0] == '\0'))
+        {
+            emitError("Failed to open commissioning window: no pairing data returned\n");
+        }
+        else
+        {
+            emitOutput("Commissioning window opened:\n");
+            emitOutput("\tManual code: %s\n", manualCode);
+            emitOutput("\tQR code: %s\n", qrCode);
 
-        rc = true;
+            rc = true;
+        }
     }
 
     return rc;

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -121,10 +121,8 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
         timeoutSeconds = (guint16) g_ascii_strtoull(argv[1], NULL, 10);
     }
 
-    BCoreCommissioningInfo *commissioningInfo =
+    g_autoptr(BCoreCommissioningInfo) commissioningInfo =
         b_core_client_open_commissioning_window(client, (argc >= 1 ? argv[0] : NULL), timeoutSeconds);
-
-    g_autoptr(BCoreCommissioningInfo) autoCommissioningInfo = commissioningInfo;
 
     if (commissioningInfo == NULL)
     {

--- a/reference/src/matterCategory.c
+++ b/reference/src/matterCategory.c
@@ -103,30 +103,57 @@ static bool openCommissioningWindow(BCoreClient *client, gint argc, gchar **argv
 
     bool rc = false;
 
-    /* If a target device id was provided and it's not the local ("0"), verify
-     * the device exists before attempting to open its commissioning window.
-     * Normalize the device ID by zero-padding it to 16 hex characters to ensure
-     * it matches the stored Matter device UUID format. */
-    if (argc >= 1 && strcmp(argv[0], "0") != 0)
+    /* If a target device id was provided, parse and validate it.
+     * Treat nodeId == 0 as local.
+     * Otherwise, verify the device exists after normalizing the ID. */
+    if (argc >= 1)
     {
-        g_autofree gchar *normalizedId = g_strdup_printf("%016llx",
-            (unsigned long long) g_ascii_strtoull(argv[0], NULL, 16));
-        g_autoptr(BCoreDevice) device = b_core_client_get_device_by_id(client, normalizedId);
-        if (device == NULL)
+        char *endptr = NULL;
+        unsigned long long nodeId = g_ascii_strtoull(argv[0], &endptr, 16);
+
+        if (endptr == argv[0] || *endptr != '\0')
         {
-            emitError("No device with node id '%s' found\n", argv[0]);
+            emitError("Invalid node id '%s'\n", argv[0]);
             return false;
+        }
+
+        /* If not local (nodeId != 0), verify device exists */
+        if (nodeId != 0)
+        {
+            g_autofree gchar *normalizedId =
+                g_strdup_printf("%016llx", nodeId);
+
+            g_autoptr(BCoreDevice) device =
+                b_core_client_get_device_by_id(client, normalizedId);
+
+            if (device == NULL)
+            {
+                emitError("No device with node id '%s' found\n", argv[0]);
+                return false;
+            }
         }
     }
 
     guint16 timeoutSeconds = 0; // let device service pick the default
     if (argc == 2)
     {
-        timeoutSeconds = (guint16) g_ascii_strtoull(argv[1], NULL, 10);
+        char *endptr = NULL;
+        unsigned long long timeout = g_ascii_strtoull(argv[1], &endptr, 10);
+
+        if (endptr == argv[1] || *endptr != '\0' || timeout > G_MAXUINT16)
+        {
+            emitError("Invalid timeout '%s'\n", argv[1]);
+            return false;
+        }
+
+        timeoutSeconds = (guint16) timeout;
     }
 
     g_autoptr(BCoreCommissioningInfo) commissioningInfo =
-        b_core_client_open_commissioning_window(client, (argc >= 1 ? argv[0] : NULL), timeoutSeconds);
+        b_core_client_open_commissioning_window(
+            client,
+            (argc >= 1 ? argv[0] : NULL),
+            timeoutSeconds);
 
     if (commissioningInfo == NULL)
     {


### PR DESCRIPTION
The ocw command was returning setup codes for non-existent device IDs instead of reporting an error. Add validation to check if the target device exists on the fabric before attempting the operation.

Refs: BARTON-227