### PR TITLE
build(docker): Add optional debuginfod volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
     "initializeCommand": "docker/setupDockerEnv.sh",
     "dockerComposeFile": [
         "../docker/compose.yaml",
-        "../docker/compose.devcontainer.yaml"
+        "../docker/compose.devcontainer.yaml",
+        "../docker/compose.debuginfod-cache.yaml"
     ],
     "service": "barton",
 

--- a/docker/compose.debuginfod-cache.yaml
+++ b/docker/compose.debuginfod-cache.yaml
@@ -1,0 +1,51 @@
+# ------------------------------ tabstop = 4 ----------------------------------
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# ------------------------------ tabstop = 4 ----------------------------------
+
+#
+# Docker Compose override to bind-mount the host's debuginfod cache into the
+# container. This avoids re-downloading debug symbols that have already been
+# fetched on the host.
+#
+# The HOST_DEBUGINFOD_CACHE variable is written to docker/.env by
+# setupDockerEnv.sh when the host cache directory exists.
+#
+# Usage:
+#   - CLI (dockerw): Use the -D flag:
+#       ./dockerw -D bash
+#
+#   - Devcontainer: Add this file to the dockerComposeFile array in
+#     .devcontainer/devcontainer.json:
+#
+#       "dockerComposeFile": [
+#           "../docker/compose.yaml",
+#           "../docker/compose.devcontainer.yaml",
+#           "../docker/compose.debuginfod-cache.yaml"
+#       ]
+#
+
+services:
+    barton:
+        volumes:
+            - ${HOST_DEBUGINFOD_CACHE}:${HOST_DEBUGINFOD_CACHE}:cached
+        environment:
+            - DEBUGINFOD_CACHE_PATH=${HOST_DEBUGINFOD_CACHE}

--- a/docker/setupDockerEnv.sh
+++ b/docker/setupDockerEnv.sh
@@ -180,6 +180,13 @@ echo "LSAN_OPTIONS=suppressions=$BARTON_TOP/testing/lsan.supp" >> $OUTFILE
 echo "BARTON_PYTHONPATH=/usr/local/lib/python3.x/dist-packages:/usr/lib/python3/dist-packages:$BARTON_TOP" >> $OUTFILE
 # path to libbCore.so
 echo "LIB_BARTON_SHARED_PATH=/usr/local/lib" >> $OUTFILE
+# debuginfod cache: if the host has a cache directory, record its path so it can be
+# bind-mounted into the container via the compose.debuginfod-cache.yaml overlay.
+HOST_DEBUGINFOD_CACHE="${DEBUGINFOD_CACHE_PATH:-$HOME/.cache/debuginfod_client}"
+if [ -d "$HOST_DEBUGINFOD_CACHE" ]; then
+    echo "HOST_DEBUGINFOD_CACHE=$HOST_DEBUGINFOD_CACHE" >> $OUTFILE
+    echo "DEBUGINFOD_CACHE_PATH=$HOST_DEBUGINFOD_CACHE" >> $OUTFILE
+fi
 ##############################################################################
 
 # Ensure the container network exists

--- a/dockerw
+++ b/dockerw
@@ -38,8 +38,9 @@ COMPOSE_INTERACTIVE_FLAGS=""
 EXTRA_ENV="-e SSH_AUTH_SOCK"
 DEV_VOL=""
 HOST_NETWORK=""
+DEBUGINFOD_CACHE_VOL=""
 
-while getopts ":ne:dH" opt; do
+while getopts ":ne:dHD" opt; do
     case ${opt} in
     n) # process option n
         COMPOSE_INTERACTIVE_FLAGS="--no-TTY"
@@ -53,6 +54,16 @@ while getopts ":ne:dH" opt; do
     H) # use host networking (useful for Matter device access)
         HOST_NETWORK="--network host"
         ;;
+    D) # mount host debuginfod cache into container
+        _cache="${DEBUGINFOD_CACHE_PATH:-$HOME/.cache/debuginfod_client}"
+        if [ -d "$_cache" ]; then
+            DEBUGINFOD_CACHE_VOL="-v $_cache:$_cache:cached"
+            EXTRA_ENV="${EXTRA_ENV} -e DEBUGINFOD_CACHE_PATH=$_cache"
+        else
+            echo "WARNING: debuginfod cache directory '$_cache' does not exist, skipping mount." >&2
+        fi
+        unset _cache
+        ;;
     esac
 done
 shift "$(($OPTIND - 1))"
@@ -64,7 +75,7 @@ $DIR/docker/setupDockerEnv.sh
 
 COMPOSE_FILE="${DIR}/docker/compose.yaml"
 
-EXTRA_VOLUMES="${DEV_VOL}"
+EXTRA_VOLUMES="${DEV_VOL} ${DEBUGINFOD_CACHE_VOL}"
 
 VOLUMES_ARGS="-v $HOME:$HOME
              $EXTRA_VOLUMES"


### PR DESCRIPTION
This commit adds an optional debuginfod volume compose file. If there is a DEBUGINFOD_CACHE_PATH environment variable set, it will use that. Else, it will use the default $HOME/.cache/debuginfod_client path. This will allow people to persist a cache across BartonCore containers.