### PR TITLE
fix: race condition in deviceCommunicationWatchdog shutdown

### DIFF
--- a/core/src/deviceCommunicationWatchdog.c
+++ b/core/src/deviceCommunicationWatchdog.c
@@ -247,7 +247,7 @@ void deviceCommunicationWatchdogPetDevice(const char *uuid)
         restoredCb = restoredCallback;
         pthread_mutex_unlock(&controlMutex);
 
-        if (restoredCb != NULL)
+        if (restoredCb)
         {
             restoredCb(uuid);
         }
@@ -310,7 +310,7 @@ void deviceCommunicationWatchdogForceDeviceInCommFail(const char *uuid)
         failedCb = failedCallback;
         pthread_mutex_unlock(&controlMutex);
 
-        if (failedCb != NULL)
+        if (failedCb)
         {
             failedCb(uuid);
         }
@@ -474,9 +474,9 @@ static void *commFailWatchdogThreadProc(void *arg)
         // Re-check running after wakeup — if Term() signaled us, exit
         // immediately rather than iterating devices and calling into
         // potentially half-torn-down subsystems.
-        if (running == false)
+        if (!running)
         {
-            icLogInfo(LOG_TAG, "%s exiting after Term signal", __FUNCTION__);
+            icInfo("exiting after Term signal");
             pthread_mutex_unlock(&controlMutex);
             break;
         }
@@ -539,9 +539,9 @@ static void *commFailWatchdogThreadProc(void *arg)
             failedCb = failedCallback;
             pthread_mutex_unlock(&controlMutex);
 
-            if (failedCb != NULL)
+            if (failedCb)
             {
-                icLogDebug(LOG_TAG, "%s: notifying callback of comm fail on %s", __FUNCTION__, commFailUuid);
+                icDebug("notifying callback of comm fail on %s", commFailUuid);
                 failedCb(commFailUuid);
             }
             iter++;

--- a/core/src/deviceCommunicationWatchdog.c
+++ b/core/src/deviceCommunicationWatchdog.c
@@ -241,9 +241,15 @@ void deviceCommunicationWatchdogPetDevice(const char *uuid)
 
     if (doNotify == true)
     {
-        if (restoredCallback != NULL)
+        void (*restoredCb)(const char *) = NULL;
+
+        pthread_mutex_lock(&controlMutex);
+        restoredCb = restoredCallback;
+        pthread_mutex_unlock(&controlMutex);
+
+        if (restoredCb != NULL)
         {
-            restoredCallback(uuid);
+            restoredCb(uuid);
         }
     }
 }
@@ -298,9 +304,15 @@ void deviceCommunicationWatchdogForceDeviceInCommFail(const char *uuid)
 
     if (doNotify == true)
     {
-        if (failedCallback != NULL)
+        void (*failedCb)(const char *) = NULL;
+
+        pthread_mutex_lock(&controlMutex);
+        failedCb = failedCallback;
+        pthread_mutex_unlock(&controlMutex);
+
+        if (failedCb != NULL)
         {
-            failedCallback(uuid);
+            failedCb(uuid);
         }
     }
 }

--- a/core/src/deviceCommunicationWatchdog.c
+++ b/core/src/deviceCommunicationWatchdog.c
@@ -132,6 +132,12 @@ void deviceCommunicationWatchdogTerm()
 
     running = false;
 
+    // NULL out callbacks while still holding controlMutex — prevents other
+    // threads (PetDevice, ForceDeviceInCommFail) from invoking callbacks
+    // into half-torn-down subsystems during shutdown.
+    failedCallback = NULL;
+    restoredCallback = NULL;
+
     pthread_cond_broadcast(&controlCond);
 
     pthread_mutex_unlock(&controlMutex);
@@ -145,9 +151,6 @@ void deviceCommunicationWatchdogTerm()
     g_hash_table_destroy(monitoredDevices);
     monitoredDevices = NULL;
     pthread_mutex_unlock(&monitoredDevicesMutex);
-
-    failedCallback = NULL;
-    restoredCallback = NULL;
 }
 
 void deviceCommunicationWatchdogMonitorDevice(const char *uuid, const uint32_t commFailTimeoutSeconds, bool inCommFail)
@@ -238,7 +241,10 @@ void deviceCommunicationWatchdogPetDevice(const char *uuid)
 
     if (doNotify == true)
     {
-        restoredCallback(uuid);
+        if (restoredCallback != NULL)
+        {
+            restoredCallback(uuid);
+        }
     }
 }
 
@@ -292,7 +298,10 @@ void deviceCommunicationWatchdogForceDeviceInCommFail(const char *uuid)
 
     if (doNotify == true)
     {
-        failedCallback(uuid);
+        if (failedCallback != NULL)
+        {
+            failedCallback(uuid);
+        }
     }
 }
 
@@ -450,6 +459,16 @@ static void *commFailWatchdogThreadProc(void *arg)
             incrementalCondTimedWaitMillis(&controlCond, &controlMutex, monitorThreadSleepSeconds);
         }
 
+        // Re-check running after wakeup — if Term() signaled us, exit
+        // immediately rather than iterating devices and calling into
+        // potentially half-torn-down subsystems.
+        if (running == false)
+        {
+            icLogInfo(LOG_TAG, "%s exiting after Term signal", __FUNCTION__);
+            pthread_mutex_unlock(&controlMutex);
+            break;
+        }
+
         bool isCommfailFast = fastCommFailTimer;
 
         pthread_mutex_unlock(&controlMutex);
@@ -502,8 +521,11 @@ static void *commFailWatchdogThreadProc(void *arg)
         while (iter < uuidsInCommFail->len)
         {
             gchar *commFailUuid = g_ptr_array_index(uuidsInCommFail, iter);
-            icLogDebug(LOG_TAG, "%s: notifying callback of comm fail on %s", __FUNCTION__, commFailUuid);
-            failedCallback(commFailUuid);
+            if (failedCallback != NULL)
+            {
+                icLogDebug(LOG_TAG, "%s: notifying callback of comm fail on %s", __FUNCTION__, commFailUuid);
+                failedCallback(commFailUuid);
+            }
             iter++;
         }
 

--- a/core/src/deviceCommunicationWatchdog.c
+++ b/core/src/deviceCommunicationWatchdog.c
@@ -521,10 +521,16 @@ static void *commFailWatchdogThreadProc(void *arg)
         while (iter < uuidsInCommFail->len)
         {
             gchar *commFailUuid = g_ptr_array_index(uuidsInCommFail, iter);
-            if (failedCallback != NULL)
+            void (*failedCb)(const char *) = NULL;
+
+            pthread_mutex_lock(&controlMutex);
+            failedCb = failedCallback;
+            pthread_mutex_unlock(&controlMutex);
+
+            if (failedCb != NULL)
             {
                 icLogDebug(LOG_TAG, "%s: notifying callback of comm fail on %s", __FUNCTION__, commFailUuid);
-                failedCallback(commFailUuid);
+                failedCb(commFailUuid);
             }
             iter++;
         }


### PR DESCRIPTION
The commFailWatchdogThreadProc does not re-check the `running` flag after waking from its timed wait. When deviceCommunicationWatchdogTerm() sets running=false and broadcasts the condition variable, the watchdog thread wakes up but proceeds to iterate the hash table and invoke failedCallback into device drivers that may already be partially shut down by deviceServiceShutdown(). This can corrupt memory and cause a SEGV (detected by AddressSanitizer as use-after-free/double-free) when the hash table is subsequently destroyed.

Fix:
1. Re-check `running` after the condition variable wait returns, so the thread exits immediately when signaled to stop rather than performing one more (unsafe) iteration.
2. NULL out failedCallback/restoredCallback under controlMutex BEFORE broadcasting/joining the thread, so any in-flight callbacks on other paths (PetDevice, ForceDeviceInCommFail) see NULL and skip the call.
3. Guard failedCallback/restoredCallback call sites against NULL to prevent NULL-dereference races during shutdown.