### PR TITLE
chore: exclude docker/version from clangd

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,8 @@
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "files.associations": {
-        "*.sbmd": "yaml"
+        "*.sbmd": "yaml",
+        "**/docker/version": "plaintext"
     },
 
     "prettier.tabWidth": 4,


### PR DESCRIPTION
Associate `docker/version` with plaintext to stop
VS Code from highlighting it as a C/C++ error.