### PR TITLE
fix(config): switch zigbee region lookup to cpe.zigbee.region_code

### DIFF
--- a/core/src/devicePrivateProperties.h
+++ b/core/src/devicePrivateProperties.h
@@ -50,7 +50,7 @@
 #define TEST_FASTTIMERS_PROP                                  "cpe.tests.fastTimers"
 #define CPE_ZIGBEE_CHANNEL_CHANGE_ENABLED_KEY                 "cpe.zigbee.channelChange.enabled"
 #define CPE_ZIGBEE_CHANNEL_CHANGE_MAX_REJOIN_WAITTIME_MINUTES "cpe.zigbee.channelChange.maxWaitTimeMin"
-#define CPE_REGION_CODE_PROPERTY_NAME                         "country_code"
+#define CPE_ZIGBEE_REGION_CODE                                "cpe.zigbee.region_code"
 #define ZIGBEE_HEALTH_CHECK_INTERVAL_MILLIS                   "cpe.zigbee.healthCheck.intervalMillis"
 #define ZIGBEE_HEALTH_CHECK_CCA_THRESHOLD                     "cpe.zigbee.healthCheck.ccaThreshold"
 #define ZIGBEE_HEALTH_CHECK_CCA_FAILURE_THRESHOLD             "cpe.zigbee.healthCheck.ccaFailureThreshold"

--- a/core/src/subsystems/zigbee/zigbeeSubsystem.c
+++ b/core/src/subsystems/zigbee/zigbeeSubsystem.c
@@ -792,8 +792,9 @@ static bool initializeNetwork(void)
     }
 
     uint64_t localEui64 = loadLocalEui64();
-    scoped_generic char *region = b_core_property_provider_get_property_as_string(
-        propertyProvider, CPE_REGION_CODE_PROPERTY_NAME, "US");
+
+    scoped_generic char *region =
+        b_core_property_provider_get_property_as_string(propertyProvider, CPE_ZIGBEE_REGION_CODE, NULL);
 
     for (int i = 0; i < MAX_NETWORK_INIT_RETRIES; ++i)
     {

--- a/core/src/zhal/c/src/zhalRequests.c
+++ b/core/src/zhal/c/src/zhalRequests.c
@@ -58,7 +58,7 @@ static void setAddress(uint64_t eui64, cJSON *request);
 
 int zhalNetworkInit(uint64_t eui64, const char *region, const char *networkConfigData, icStringHashMap *properties)
 {
-    icLogDebug(LOG_TAG, "zhalNetworkInit: eui64=%016" PRIx64 ", region = %s", eui64, region);
+    icLogDebug(LOG_TAG, "zhalNetworkInit: eui64=%016" PRIx64 ", region = %s", eui64, stringCoalesceAlt(region, NULL));
 
     cJSON *request = cJSON_CreateObject();
 


### PR DESCRIPTION
Replace legacy country_code key with cpe.zigbee.region_code and update zigbee subsystem lookup to the new property.

Refs: XHCPE-2544

---------