### PR TITLE
fix(matter): populate VID/PID/flow in local commissioning payload

### DIFF
--- a/api/c/public/barton-core-properties.h
+++ b/api/c/public/barton-core-properties.h
@@ -200,6 +200,18 @@ G_BEGIN_DECLS
     B_CORE_BARTON_PREFIX B_CORE_MATTER_PREFIX "setupPasscode"
 
 /**
+ * MATTER_COMMISSIONING_FLOW: (value "barton.matter.commissioningFlow")
+ *
+ * The commissioning flow advertised in the Matter device's onboarding payload
+ * (QR code and manual setup code). Valid values match the Matter Commissioning
+ * Flow field: 0 = Standard, 1 = User Action Required, 2 = Custom.
+ * This property is optional; when unset it defaults to Standard (0).
+ * Property Value Type: uint8
+ */
+#define B_CORE_BARTON_MATTER_COMMISSIONING_FLOW                                                              \
+    B_CORE_BARTON_PREFIX B_CORE_MATTER_PREFIX "commissioningFlow"
+
+/**
  * MATTER_SPAKE2P_ITERATION_COUNT: (value "barton.matter.spake2pIterationCount")
  *
  * The iteration count for the Matter device's spake2p verifier.

--- a/core/src/subsystems/matter/Matter.cpp
+++ b/core/src/subsystems/matter/Matter.cpp
@@ -1327,10 +1327,51 @@ bool Matter::OpenCommissioningWindow(chip::NodeId nodeId,
 
     if (nodeId == 0)
     {
+        // This is the local node ("us"), so the onboarding payload must carry our own identity: vendor id,
+        // product id, and commissioning flow. Vendor id and product id come from the DeviceInstanceInfoProvider,
+        // the same source the SDK uses for the DNS-SD TXT record and onboarding codes.
+        if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetVendorId(setupPayload.vendorID) != CHIP_NO_ERROR)
+        {
+            icError("Failed to get vendor id from DeviceInstanceInfoProvider");
+            return false;
+        }
+
+        if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetProductId(setupPayload.productID) != CHIP_NO_ERROR)
+        {
+            icError("Failed to get product id from DeviceInstanceInfoProvider");
+            return false;
+        }
+
+        // The commissioning flow (standard/user-action-required/custom) is Barton configuration; the Matter SDK
+        // provides no source for it (it is not part of the DNS-SD TXT record and has no provider/config hook).
+        // Default to standard when the property is unset or invalid.
+        g_autoptr(BCorePropertyProvider) propertyProvider = deviceServiceConfigurationGetPropertyProvider();
+        uint8_t commissioningFlowValue = b_core_property_provider_get_property_as_uint8(
+            propertyProvider, B_CORE_BARTON_MATTER_COMMISSIONING_FLOW, to_underlying(CommissioningFlow::kStandard));
+
+        switch (static_cast<CommissioningFlow>(commissioningFlowValue))
+        {
+            case CommissioningFlow::kStandard:
+            case CommissioningFlow::kUserActionRequired:
+            case CommissioningFlow::kCustom:
+                setupPayload.commissioningFlow = static_cast<CommissioningFlow>(commissioningFlowValue);
+                break;
+            default:
+                icWarn("Invalid commissioning flow value %" PRIu8 " configured; defaulting to standard",
+                       commissioningFlowValue);
+                setupPayload.commissioningFlow = CommissioningFlow::kStandard;
+                break;
+        }
+
         success = OpenLocalCommissioningWindow(discriminator, timeoutSecs, setupPayload);
     }
     else
     {
+        // TODO: This opens a commissioning window on a *remote* device, so the onboarding payload should
+        // report that device's vendor id, product id, and commissioning flow rather than ours. We do not
+        // currently have those values for the remote device, so vendor id, product id, and commissioning
+        // flow are left as zeros. This assumes the standard commissioning flow, which allows zeros for
+        // those three fields.
         chip::DeviceLayer::PlatformMgr().LockChipStack();
 
         success = CHIP_NO_ERROR == Controller::AutoCommissioningWindowOpener::OpenCommissioningWindow(

--- a/core/src/subsystems/matter/Matter.cpp
+++ b/core/src/subsystems/matter/Matter.cpp
@@ -1347,7 +1347,9 @@ bool Matter::OpenCommissioningWindow(chip::NodeId nodeId,
         // Default to standard when the property is unset or invalid.
         g_autoptr(BCorePropertyProvider) propertyProvider = deviceServiceConfigurationGetPropertyProvider();
         uint8_t commissioningFlowValue = b_core_property_provider_get_property_as_uint8(
-            propertyProvider, B_CORE_BARTON_MATTER_COMMISSIONING_FLOW, to_underlying(CommissioningFlow::kStandard));
+            propertyProvider,
+            B_CORE_BARTON_MATTER_COMMISSIONING_FLOW,
+            static_cast<uint8_t>(CommissioningFlow::kStandard));
 
         switch (static_cast<CommissioningFlow>(commissioningFlowValue))
         {

--- a/reference/src/barton-core-reference-app.c
+++ b/reference/src/barton-core-reference-app.c
@@ -203,6 +203,11 @@ static void setDefaultParameters(BCoreInitializeParamsContainer *params)
         // 0x8001 unless defined in the custom DeviceConfig header (see src/include/platform/CHIPDeviceConfig.h).
         b_core_property_provider_set_property_uint16(propProvider, B_CORE_BARTON_MATTER_PRODUCT_ID, 0x8001);
 
+        // Commissioning flow advertised in the onboarding payload (QR code / manual setup code).
+        // 0 = Standard, 1 = User Action Required, 2 = Custom. Standard is used here; a product that
+        // requires a custom commissioning flow would set this to 2.
+        b_core_property_provider_set_property_uint8(propProvider, B_CORE_BARTON_MATTER_COMMISSIONING_FLOW, 0);
+
         b_core_property_provider_set_property_uint16(
             propProvider, B_CORE_BARTON_MATTER_HARDWARE_VERSION, 1);
 


### PR DESCRIPTION
When opening a commissioning window for the local node (node 0), the generated QR code and manual setup code reported zeros for vendor id, product id, and commissioning flow because SetupPayload was never populated with them.

Populate vendor id and product id from the DeviceInstanceInfoProvider (the same source the SDK uses for the DNS-SD TXT record) and add a new optional Barton property, barton.matter.commissioningFlow, to source the commissioning flow, since the SDK provides no hook for it. This is done only on the node-0 path, which advertises our own identity.

The remote path opens a commissioning window on another device and must report that device's values; leave those three fields as zeros for now with a TODO, which assumes the standard flow that permits zeros.

Refs: BARTON-398