### PR TITLE
chore: update dev environment and integration tests for SBMD v4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,9 @@
 
         // see `docker/setupDockerEnv.sh` for more details on these custom PATHs
         // NOTE: do not add a custom PATH here without first defining it in setupDockerEnv.sh
-        "LD_LIBRARY_PATH": "${containerEnv:LD_LIBRARY_PATH}:${containerEnv:LIB_BARTON_SHARED_PATH}",
+        // Build-tree path comes first so freshly compiled libraries are used without `make install`.
+        // The installed system path is kept as a fallback for libraries not built locally.
+        "LD_LIBRARY_PATH": "${containerWorkspaceFolder}/build/core:${containerEnv:LD_LIBRARY_PATH}:${containerEnv:LIB_BARTON_SHARED_PATH}",
         "PYTHONPATH": "${containerEnv:PYTHONPATH}:${containerEnv:BARTON_PYTHONPATH}",
 
         // ASAN-instrumented libBartonCore.so requires the link order check to be disabled

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,7 @@
         // NOTE: do not add a custom PATH here without first defining it in setupDockerEnv.sh
         // Build-tree path comes first so freshly compiled libraries are used without `make install`.
         // The installed system path is kept as a fallback for libraries not built locally.
-        "LD_LIBRARY_PATH": "${containerWorkspaceFolder}/build/core:${containerEnv:LD_LIBRARY_PATH}:${containerEnv:LIB_BARTON_SHARED_PATH}",
+        "LD_LIBRARY_PATH": "${containerWorkspaceFolder}/build/core:${containerEnv:LIB_BARTON_SHARED_PATH}",
         "PYTHONPATH": "${containerEnv:PYTHONPATH}:${containerEnv:BARTON_PYTHONPATH}",
 
         // ASAN-instrumented libBartonCore.so requires the link order check to be disabled

--- a/.github/skills/validate-sbmd/SKILL.md
+++ b/.github/skills/validate-sbmd/SKILL.md
@@ -37,7 +37,7 @@ This:
 2. Extracts the `SbmdDriver()` registration object as JSON (functions → `true`)
 3. Validates the JSON against `sbmd-spec-schema-v4.0.json`
 
-This regenerates `build/sbmd-stubs.json` from the TypeScript interface definitions in `sbmd-script.d.ts`. The stubs are used by the validator to check JavaScript against the expected API surface.
+The validator evaluates each `.sbmd.js` file, extracts the `SbmdDriver()` registration object, and validates it against the JSON schema.
 
 ## File Locations
 

--- a/.github/skills/validate-sbmd/SKILL.md
+++ b/.github/skills/validate-sbmd/SKILL.md
@@ -45,7 +45,7 @@ The validator evaluates each `.sbmd.js` file, extracts the `SbmdDriver()` regist
 |------|----------|
 | SBMD spec files | `core/deviceDrivers/matter/sbmd/specs/*.sbmd.js` |
 | JSON schema | `core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json` |
-| TypeScript definitions | `core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts` |
+| TypeScript definitions (editor tooling only — not used by the validator) | `core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts` |
 | Validation script | `scripts/ci/validate_sbmd_v4_specs.py` |
 | Extraction harness | `scripts/ci/sbmd_extract_registration.js` |
 
@@ -63,4 +63,4 @@ If `python3` or validation dependencies are not found:
 
 1. Check if `/.dockerenv` exists
 2. If it does NOT exist, stop and tell the user: **"Validation tools are not available. Please run inside the BartonCore development container."**
-3. If it does exist, ensure the project has been built at least once (stubs are generated during build)
+3. If it does exist, ensure the validator's dependencies are installed: Node.js (used to extract the `SbmdDriver()` registration object) and the `jsonschema` Python package (used to validate it against the schema)

--- a/.github/skills/validate-sbmd/SKILL.md
+++ b/.github/skills/validate-sbmd/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: validate-sbmd
-description: Validate SBMD (Spec-Based Matter Driver) specification files. Use when the user has edited .sbmd files, wants to check schema conformance, verify embedded JavaScript syntax, or regenerate TypeScript stubs. Covers the validation script, stub generator, spec file locations, and automatic build-time validation.
+description: Validate SBMD (Spec-Based Matter Driver) v4 specification files. Use when the user has edited .sbmd.js files, wants to check schema conformance, or verify driver structure. Covers the validation script, JSON schema, spec file locations, and automatic build-time validation.
 license: Apache-2.0
-compatibility: Requires the BartonCore Docker development container with Python 3 and a JavaScript engine (mquickjs or quickjs).
+compatibility: Requires the BartonCore Docker development container with Python 3, Node.js, and the jsonschema Python package.
 metadata:
   author: rdkcentral
-  version: "1.0"
+  version: "2.0"
 ---
 
 # Validate SBMD Specs
 
-SBMD (Spec-Based Matter Drivers) are declarative YAML files with embedded JavaScript that map Matter protocol operations to BartonCore resources. Validation ensures schema conformance and JavaScript syntax correctness.
+SBMD v4 drivers are `.sbmd.js` JavaScript files that register a driver via `SbmdDriver({...})`. Validation ensures the registration object conforms to the JSON schema.
 
 ## Automatic Validation (During Build)
 
@@ -20,33 +20,22 @@ When `BCORE_MATTER_VALIDATE_SCHEMAS=ON` (the default), SBMD validation runs auto
 cmake --build build
 ```
 
-This generates stubs from TypeScript definitions and validates all `.sbmd` files in one step. **This is the easiest way to validate.**
+The `validate_sbmd_specs` target uses Node.js to extract each driver's registration object and validates it against the JSON schema. **This is the easiest way to validate.**
 
 ## Manual Validation
 
 ### Validate SBMD Spec Files
 
 ```bash
-python3 scripts/ci/validate_sbmd_specs.py \
+python3 scripts/ci/validate_sbmd_v4_specs.py \
     core/deviceDrivers/matter/sbmd/schema \
-    core/deviceDrivers/matter/sbmd/specs/*.sbmd \
-    --stubs build/sbmd-stubs.json
+    core/deviceDrivers/matter/sbmd/specs/*.sbmd.js
 ```
 
-This checks:
-- YAML structure against the JSON schema
-- Embedded JavaScript syntax using a JS engine
-- Schema version resolution using each spec's `schemaVersion`
-
-### Regenerate TypeScript Stubs
-
-If TypeScript definition files have changed:
-
-```bash
-python3 scripts/ci/generate_sbmd_stubs.py \
-    core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts \
-    build/sbmd-stubs.json
-```
+This:
+1. Uses Node.js to evaluate each `.sbmd.js` file in a sandbox
+2. Extracts the `SbmdDriver()` registration object as JSON (functions → `true`)
+3. Validates the JSON against `sbmd-spec-schema-v4.0.json`
 
 This regenerates `build/sbmd-stubs.json` from the TypeScript interface definitions in `sbmd-script.d.ts`. The stubs are used by the validator to check JavaScript against the expected API surface.
 
@@ -54,13 +43,11 @@ This regenerates `build/sbmd-stubs.json` from the TypeScript interface definitio
 
 | Item | Location |
 |------|----------|
-| SBMD spec files | `core/deviceDrivers/matter/sbmd/specs/*.sbmd` |
-| JSON schemas | `core/deviceDrivers/matter/sbmd/schema/` (e.g., `schema/v2/sbmd-spec-schema-v2.1.json`) |
+| SBMD spec files | `core/deviceDrivers/matter/sbmd/specs/*.sbmd.js` |
+| JSON schema | `core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json` |
 | TypeScript definitions | `core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts` |
-| Generated stubs | `build/sbmd-stubs.json` |
-| Validation script | `scripts/ci/validate_sbmd_specs.py` |
-| Stub generator | `scripts/ci/generate_sbmd_stubs.py` |
-| JS embedding script | `scripts/embed-js-as-header.py` |
+| Validation script | `scripts/ci/validate_sbmd_v4_specs.py` |
+| Extraction harness | `scripts/ci/sbmd_extract_registration.js` |
 
 ## Discovering Available SBMD Specs
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -97,7 +97,7 @@
             "name": "(gdb) Reference App No Thread",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/reference/barton-core-reference ",
+            "program": "${workspaceFolder}/build/reference/barton-core-reference",
             "args": [
                 "-t",
                 "-b",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,9 +14,18 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/reference/barton-core-reference",
-            "args": ["-b", "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"],
+            "args": [
+                "-b",
+                "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/build/core:${env:LD_LIBRARY_PATH}"
+                }
+            ],
             "externalConsole": false,
             "MIMode": "gdb",
             "setupCommands": [
@@ -32,9 +41,19 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/reference/barton-core-reference",
-            "args": ["-z", "-b", "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"],
+            "args": [
+                "-z",
+                "-b",
+                "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/build/core:${env:LD_LIBRARY_PATH}"
+                }
+            ],
             "externalConsole": false,
             "MIMode": "gdb",
             "setupCommands": [
@@ -50,9 +69,20 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/reference/barton-core-reference",
-            "args": ["-z", "-t", "-b", "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"],
+            "args": [
+                "-z",
+                "-t",
+                "-b",
+                "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/build/core:${env:LD_LIBRARY_PATH}"
+                }
+            ],
             "externalConsole": false,
             "MIMode": "gdb",
             "setupCommands": [
@@ -68,9 +98,19 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/reference/barton-core-reference ",
-            "args": ["-t", "-b", "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"],
+            "args": [
+                "-t",
+                "-b",
+                "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/build/core:${env:LD_LIBRARY_PATH}"
+                }
+            ],
             "externalConsole": false,
             "MIMode": "gdb",
             "setupCommands": [
@@ -89,6 +129,12 @@
             "args": ["-m", "-t"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/build/core:${env:LD_LIBRARY_PATH}"
+                }
+            ],
             "externalConsole": false,
             "MIMode": "gdb",
             "setupCommands": [
@@ -104,9 +150,20 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/reference/barton-core-reference",
-            "args": ["-z", "-t", "-b", "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"],
+            "args": [
+                "-z",
+                "-t",
+                "-b",
+                "${workspaceFolder}/core/deviceDrivers/matter/sbmd/specs"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/build/core:${env:LD_LIBRARY_PATH}"
+                }
+            ],
             "externalConsole": false,
             "MIMode": "gdb",
             "setupCommands": [

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -732,7 +732,7 @@ std::string SpecBasedMatterDeviceDriver::InvokeSeedHandler(const std::string &de
         // args keeps its value alive for its whole lifetime, so it survives the allocations in
         // AddSupplements and the handler call without a separate guard.
         SafeJSValue args = SbmdHandlerInvoker::BuildResourceArgs(ctx, hctx, resource.id, std::nullopt);
-        SbmdHandlerInvoker::AddSupplements(ctx, args, supplements);
+        SbmdHandlerInvoker::AddSupplements(ctx, args, resource.seed->supplements, supplements);
         result = SbmdHandlerInvoker::InvokeHandler(ctx, resource.seed->Fn(), args);
     }
 
@@ -942,7 +942,7 @@ void SpecBasedMatterDeviceDriver::HandleResourceOp(std::forward_list<std::promis
         // args keeps its value alive for its whole lifetime, so it survives the allocations in
         // AddSupplements and the handler call without a separate guard.
         SafeJSValue args = SbmdHandlerInvoker::BuildResourceArgs(ctx, hctx, resourceId, inputValue);
-        SbmdHandlerInvoker::AddSupplements(ctx, args, supplements);
+        SbmdHandlerInvoker::AddSupplements(ctx, args, handler->supplements, supplements);
         result = SbmdHandlerInvoker::InvokeHandler(ctx, handler->Fn(), args);
     }
 
@@ -2064,7 +2064,7 @@ void SpecBasedMatterDeviceDriver::DispatchToHandlers(const std::string &deviceId
             // args keeps its value alive for its whole lifetime, so it survives the allocations in
             // AddSupplements and the handler call without a separate guard.
             SafeJSValue args = buildArgs(ctx);
-            SbmdHandlerInvoker::AddSupplements(ctx, args, supplements);
+            SbmdHandlerInvoker::AddSupplements(ctx, args, entry->handler->supplements, supplements);
             result = SbmdHandlerInvoker::InvokeHandler(ctx, entry->handler->Fn(), args);
         }
 

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -571,8 +571,15 @@ bool SpecBasedMatterDeviceDriver::DoRegisterDriverResources(icDevice *device)
 
     // Resolve the MatterDevice so seed handlers can prefetch declared supplements from the
     // attribute cache. Without it InvokeSeedHandler skips the prefetch and a seed that reads
-    // args.supplements would see undefined.
+    // a declared supplement receives null (see the supplement contract in AddSupplements).
     auto matterDevice = GetDevice(device->uuid);
+
+    if (matterDevice == nullptr)
+    {
+        icWarn("Could not resolve MatterDevice for %s during resource registration; seed "
+               "handlers that declare attribute supplements will receive null values",
+               device->uuid);
+    }
 
     std::map<std::string, icDeviceEndpoint *> icEndpoints; // endpoint id → created endpoint
 

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -569,6 +569,11 @@ bool SpecBasedMatterDeviceDriver::DoRegisterDriverResources(icDevice *device)
 
     icDebug("Registering resources for device %s", device->uuid);
 
+    // Resolve the MatterDevice so seed handlers can prefetch declared supplements from the
+    // attribute cache. Without it InvokeSeedHandler skips the prefetch and a seed that reads
+    // args.supplements would see undefined.
+    auto matterDevice = GetDevice(device->uuid);
+
     std::map<std::string, icDeviceEndpoint *> icEndpoints; // endpoint id → created endpoint
 
     for (const auto &endpoint : reg.endpoints)
@@ -638,7 +643,7 @@ bool SpecBasedMatterDeviceDriver::DoRegisterDriverResources(icDevice *device)
 
             if (resource.seed.has_value())
             {
-                seedValue = InvokeSeedHandler(device->uuid, endpoint.id, resource);
+                seedValue = InvokeSeedHandler(device->uuid, endpoint.id, resource, matterDevice.get());
 
                 if (!seedValue.empty())
                 {

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.h
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.h
@@ -154,7 +154,7 @@ namespace barton
         std::string InvokeSeedHandler(const std::string &deviceId,
                                       const std::string &endpointId,
                                       const SbmdResource &resource,
-                                      MatterDevice *device = nullptr);
+                                      MatterDevice *device);
 
         /**
          * Find a resource by endpoint ID and resource ID.

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.h
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.h
@@ -150,6 +150,12 @@ namespace barton
 
         /**
          * Invoke a seed handler for a resource. Returns the seed value or empty string.
+         *
+         * @param device Optional. When non-null, used to prefetch the resource's declared
+         *               supplements from the attribute cache before the handler runs. When
+         *               null, the prefetch is skipped and any declared supplements are
+         *               delivered as null (see the supplement contract in
+         *               SbmdHandlerInvoker::AddSupplements).
          */
         std::string InvokeSeedHandler(const std::string &deviceId,
                                       const std::string &endpointId,

--- a/core/deviceDrivers/matter/sbmd/mquickjs/SbmdHandlerInvoker.cpp
+++ b/core/deviceDrivers/matter/sbmd/mquickjs/SbmdHandlerInvoker.cpp
@@ -232,9 +232,21 @@ namespace barton
         return fetched;
     }
 
-    void SbmdHandlerInvoker::AddSupplements(JSContext *ctx, SafeJSValue &args, const FetchedSupplements &fetched)
+    void SbmdHandlerInvoker::AddSupplements(JSContext *ctx,
+                                            SafeJSValue &args,
+                                            const SbmdSupplements &declared,
+                                            const FetchedSupplements &fetched)
     {
-        if (fetched.empty())
+        // Contract: every supplement a driver DECLARES is materialized as a JS property on
+        // args.supplements at handler invocation. The declaration -- not the fetched data --
+        // is the source of truth, so a declared key is always defined: it holds the fetched
+        // value when available, otherwise null. This holds even when the prefetch was skipped
+        // (e.g. no device) or a fetch bug failed to populate it. Categories and keys that were
+        // not declared are omitted.
+        bool anyDeclared = !declared.attributes.empty() || !declared.resources.empty() ||
+                           !declared.persistentData.empty() || !declared.transientData.empty();
+
+        if (!anyDeclared)
         {
             return;
         }
@@ -243,31 +255,45 @@ namespace barton
         // through the reachable child. args is already a SafeJSValue owned by the caller.
         SafeJSValue supObj = args.AddObject(SBMD_KEY_SUPPLEMENTS);
 
-        auto populate = [](SafeJSValue &parent, const char *key, const std::vector<FetchedSupplement> &entries) {
-            if (entries.empty())
+        auto populate = [](SafeJSValue &parent,
+                           const char *categoryKey,
+                           const std::vector<std::string> &declaredKeys,
+                           const std::vector<FetchedSupplement> &fetchedEntries) {
+            if (declaredKeys.empty())
             {
                 return;
             }
 
-            SafeJSValue obj = parent.AddObject(key);
+            SafeJSValue obj = parent.AddObject(categoryKey);
 
-            for (const auto &entry : entries)
+            for (const auto &declaredKey : declaredKeys)
             {
-                if (entry.value.has_value())
+                const std::string *value = nullptr;
+
+                for (const auto &entry : fetchedEntries)
                 {
-                    obj.SetString(entry.key.c_str(), entry.value->c_str());
+                    if (entry.key == declaredKey && entry.value.has_value())
+                    {
+                        value = &entry.value.value();
+                        break;
+                    }
+                }
+
+                if (value != nullptr)
+                {
+                    obj.SetString(declaredKey.c_str(), value->c_str());
                 }
                 else
                 {
-                    obj.SetNull(entry.key.c_str());
+                    obj.SetNull(declaredKey.c_str());
                 }
             }
         };
 
-        populate(supObj, SBMD_KEY_ATTRIBUTES, fetched.attributes);
-        populate(supObj, SBMD_KEY_RESOURCES, fetched.resources);
-        populate(supObj, SBMD_KEY_PERSISTENT_DATA, fetched.persistentData);
-        populate(supObj, SBMD_KEY_TRANSIENT_DATA, fetched.transientData);
+        populate(supObj, SBMD_KEY_ATTRIBUTES, declared.attributes, fetched.attributes);
+        populate(supObj, SBMD_KEY_RESOURCES, declared.resources, fetched.resources);
+        populate(supObj, SBMD_KEY_PERSISTENT_DATA, declared.persistentData, fetched.persistentData);
+        populate(supObj, SBMD_KEY_TRANSIENT_DATA, declared.transientData, fetched.transientData);
     }
 
     void SbmdHandlerInvoker::ExecuteOps(const HandlerContext &hctx,

--- a/core/deviceDrivers/matter/sbmd/mquickjs/SbmdHandlerInvoker.h
+++ b/core/deviceDrivers/matter/sbmd/mquickjs/SbmdHandlerInvoker.h
@@ -255,20 +255,28 @@ namespace barton
                                                       const TransientDataFetcher &transientFetcher);
 
         /**
-         * Attach previously fetched supplements to an args object as
-         * `args.supplements`.
+         * Attach declared supplements to an args object as `args.supplements`.
+         *
+         * The declaration is the source of truth: every supplement key a driver
+         * DECLARES is materialized as a defined JS property -- set to its fetched
+         * value when available, otherwise null. A declared key is therefore never
+         * undefined, even when the prefetch was skipped (e.g. no device) or a fetch
+         * bug failed to populate it. Categories and keys that were not declared are
+         * omitted, and if nothing was declared this is a no-op.
          *
          * This only touches the JS context, so the caller must hold
          * MQuickJsRuntime::GetMutex(). Pair it with PrefetchSupplements, which
          * gathers the values beforehand without the mutex.
          *
-         * If fetched is empty (no declared keys), this is a no-op.
-         *
          * @param ctx JS context (caller holds mutex)
          * @param args The args object to augment (modified in place)
-         * @param fetched The values produced by PrefetchSupplements
+         * @param declared The supplement declarations (which keys must exist)
+         * @param fetched The values produced by PrefetchSupplements (best-effort data)
          */
-        static void AddSupplements(JSContext *ctx, SafeJSValue &args, const FetchedSupplements &fetched);
+        static void AddSupplements(JSContext *ctx,
+                                   SafeJSValue &args,
+                                   const SbmdSupplements &declared,
+                                   const FetchedSupplements &fetched);
 
         /**
          * Build an args object for a deferred command response handler.

--- a/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts
+++ b/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts
@@ -236,7 +236,7 @@ interface SbmdHandlerArgsBase {
      * A declared leaf is therefore NEVER `undefined`, so you may reach through
      * `args.supplements.<category>` without guarding the shape, BUT you MUST
      * null-check the leaf value before using it.
-     * 
+     *
      * Only declared categories/keys appear; reading a supplement you did not
      * declare yields `undefined`, so do not access undeclared supplements.
      */

--- a/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts
+++ b/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts
@@ -227,9 +227,21 @@ interface SbmdHandlerArgsBase {
     /** Feature maps for clusters declared in matter.featureClusters. */
     clusterFeatureMaps: Record<string, number>;
 
-    /** Pre-fetched supplement data, present when supplements are declared. */
+    /**
+     * Pre-fetched supplement data, present when supplements are declared.
+     *
+     * CONTRACT / LINT NOTE: every key a handler DECLARES is always present here
+     * as a defined property -- its fetched value, or `null` when that value was
+     * unavailable (uncached, storage miss, or a fetch that failed to populate).
+     * A declared leaf is therefore NEVER `undefined`, so you may reach through
+     * `args.supplements.<category>` without guarding the shape, BUT you MUST
+     * null-check the leaf value before using it.
+     * 
+     * Only declared categories/keys appear; reading a supplement you did not
+     * declare yields `undefined`, so do not access undeclared supplements.
+     */
     supplements?: {
-        attributes?: Record<string, any>;
+        attributes?: Record<string, string | null>;
         resources?: Record<string, string | null>;
         persistentData?: Record<string, string | null>;
         transientData?: Record<string, string | null>;

--- a/core/test/src/SbmdHandlerInvokerTest.cpp
+++ b/core/test/src/SbmdHandlerInvokerTest.cpp
@@ -134,7 +134,7 @@ namespace
     {
         FetchedSupplements fetched = SbmdHandlerInvoker::PrefetchSupplements(
             supplements, attrFetcher, resFetcher, persistFetcher, transientFetcher);
-        SbmdHandlerInvoker::AddSupplements(ctx, args, fetched);
+        SbmdHandlerInvoker::AddSupplements(ctx, args, supplements, fetched);
     }
 
     class SbmdHandlerInvokerTest : public ::testing::Test
@@ -844,6 +844,126 @@ namespace
 
         ASSERT_EQ(g_updateResourceCalls.size(), 1u);
         EXPECT_EQ(g_updateResourceCalls[0].value, "was-null");
+    }
+
+    // ================================================================
+    // Declared-supplement contract: every DECLARED supplement key is
+    // always a defined JS property (its value, or null) at invocation --
+    // never undefined -- even when the prefetch was skipped or a fetch
+    // bug failed to populate it. These drive AddSupplements directly with
+    // a declaration plus empty/partial fetched data to isolate the
+    // contract from the prefetch phase.
+    // ================================================================
+
+    TEST_F(SbmdHandlerInvokerTest, DeclaredSupplementsPresentWhenPrefetchSkipped)
+    {
+        auto hctx = MakeContext();
+
+        std::lock_guard<std::mutex> lock(MQuickJsRuntime::GetMutex());
+
+        SafeJSValue args = SbmdHandlerInvoker::BuildResourceArgs(Ctx(), hctx, "isOn", std::nullopt);
+
+        SbmdSupplements declared;
+        declared.attributes = {"lockState"};
+        declared.resources = {"1/locked"};
+        declared.persistentData = {"lastOp"};
+        declared.transientData = {"debounce"};
+
+        // Simulate the prefetch being skipped entirely (e.g. no device available):
+        // fetched is empty, yet every declared key must still be present as null.
+        FetchedSupplements empty;
+        SbmdHandlerInvoker::AddSupplements(Ctx(), args, declared, empty);
+
+        JSValue supObj = JS_GetPropertyStr(Ctx(), args, "supplements");
+        ASSERT_FALSE(JS_IsUndefined(supObj));
+
+        JSValue attrs = JS_GetPropertyStr(Ctx(), supObj, "attributes");
+        ASSERT_FALSE(JS_IsUndefined(attrs));
+        JSValue lockState = JS_GetPropertyStr(Ctx(), attrs, "lockState");
+        EXPECT_FALSE(JS_IsUndefined(lockState));
+        EXPECT_TRUE(JS_IsNull(lockState));
+
+        JSValue res = JS_GetPropertyStr(Ctx(), supObj, "resources");
+        ASSERT_FALSE(JS_IsUndefined(res));
+        JSValue locked = JS_GetPropertyStr(Ctx(), res, "1/locked");
+        EXPECT_FALSE(JS_IsUndefined(locked));
+        EXPECT_TRUE(JS_IsNull(locked));
+
+        JSValue pd = JS_GetPropertyStr(Ctx(), supObj, "persistentData");
+        ASSERT_FALSE(JS_IsUndefined(pd));
+        JSValue lastOp = JS_GetPropertyStr(Ctx(), pd, "lastOp");
+        EXPECT_FALSE(JS_IsUndefined(lastOp));
+        EXPECT_TRUE(JS_IsNull(lastOp));
+
+        JSValue td = JS_GetPropertyStr(Ctx(), supObj, "transientData");
+        ASSERT_FALSE(JS_IsUndefined(td));
+        JSValue debounce = JS_GetPropertyStr(Ctx(), td, "debounce");
+        EXPECT_FALSE(JS_IsUndefined(debounce));
+        EXPECT_TRUE(JS_IsNull(debounce));
+    }
+
+    TEST_F(SbmdHandlerInvokerTest, DeclaredSupplementsPresentWhenFetchDropsKey)
+    {
+        auto hctx = MakeContext();
+
+        std::lock_guard<std::mutex> lock(MQuickJsRuntime::GetMutex());
+
+        SafeJSValue args = SbmdHandlerInvoker::BuildResourceArgs(Ctx(), hctx, "isOn", std::nullopt);
+
+        SbmdSupplements declared;
+        declared.attributes = {"present", "dropped"};
+
+        // Simulate a fetch bug: only one of the two declared keys made it into fetched.
+        FetchedSupplements fetched;
+        fetched.attributes.push_back({"present", std::string("AQ==")});
+
+        SbmdHandlerInvoker::AddSupplements(Ctx(), args, declared, fetched);
+
+        JSValue supObj = JS_GetPropertyStr(Ctx(), args, "supplements");
+        JSValue attrs = JS_GetPropertyStr(Ctx(), supObj, "attributes");
+
+        // The present key carries its value.
+        EXPECT_EQ(GetStringProp(attrs, "present"), "AQ==");
+
+        // The dropped key is still DEFINED as null, never undefined.
+        JSValue dropped = JS_GetPropertyStr(Ctx(), attrs, "dropped");
+        EXPECT_FALSE(JS_IsUndefined(dropped));
+        EXPECT_TRUE(JS_IsNull(dropped));
+    }
+
+    TEST_F(SbmdHandlerInvokerTest, DeclaredSupplementSafeInHandlerWhenPrefetchSkipped)
+    {
+        auto hctx = MakeContext();
+
+        std::lock_guard<std::mutex> lock(MQuickJsRuntime::GetMutex());
+
+        // Mirrors a seed handler that reads a declared attribute. Even with no fetched
+        // data, args.supplements.attributes.lockState must be null (defined), so the
+        // handler runs without a "cannot read property of undefined" crash.
+        JSValue handler = EvalFunc("(function(args) {"
+                                   "  var v = args.supplements.attributes.lockState;"
+                                   "  var out = (v === null) ? 'null' : String(v);"
+                                   "  return Sbmd.result()"
+                                   "    .dataModel.updateResource('1', 'locked', out)"
+                                   "    .success();"
+                                   "})");
+        ASSERT_FALSE(JS_IsException(handler));
+
+        SafeJSValue args = SbmdHandlerInvoker::BuildResourceArgs(Ctx(), hctx, "locked", std::nullopt);
+
+        SbmdSupplements declared;
+        declared.attributes = {"lockState"};
+
+        FetchedSupplements empty; // prefetch skipped
+        SbmdHandlerInvoker::AddSupplements(Ctx(), args, declared, empty);
+
+        auto result = SbmdHandlerInvoker::InvokeHandler(Ctx(), handler, args);
+        ASSERT_TRUE(result.has_value());
+
+        SbmdHandlerInvoker::ExecuteOps(hctx, result->ops);
+
+        ASSERT_EQ(g_updateResourceCalls.size(), 1u);
+        EXPECT_EQ(g_updateResourceCalls[0].value, "null");
     }
 
     // ================================================================

--- a/testing/environment/base_environment_orchestrator.py
+++ b/testing/environment/base_environment_orchestrator.py
@@ -106,11 +106,13 @@ class BaseEnvironmentOrchestrator(ABC):
         # Must match what's compiled with barton matter sdk
         self._barton_storage_path = str(Path.home()) + "/.brtn-ds"
         self._matter_storage_path = self._barton_storage_path + "/matter"
-        # SBMD specs directory relative to workspace root
+        # SBMD specs directories relative to workspace root
         workspace_root = Path(__file__).parent.parent.parent
-        self._sbmd_dirs = str(
+        production_specs = str(
             workspace_root / "core" / "deviceDrivers" / "matter" / "sbmd" / "specs"
         )
+        test_specs = str(workspace_root / "testing" / "resources" / "sbmd-specs")
+        self._sbmd_dirs = production_specs + ";" + test_specs
         self._init_client()
         self._configure_client()
 

--- a/testing/test/door_lock_test.py
+++ b/testing/test/door_lock_test.py
@@ -242,16 +242,16 @@ def test_locked_resource_updated_by_event(default_environment, matter_door_lock)
     # From here, use event-driven updates via RESOURCE_UPDATED.
     resource_updated_queue = resource_update_listener(client, "locked")
 
-    # Trigger sideband unlock — DoorLockDevice.js emits LockOperation (Unlock) event
+    # Trigger sideband unlock — the device's LockState attribute transitions to Unlocked
     result = matter_door_lock.sideband.send("unlock")
     assert result["lockState"] == "unlocked"
 
-    # Barton should receive a resource update driven by the LockOperation event
+    # Barton receives the LockState attribute report and updates the resource (RESOURCE_UPDATED)
     wait_for_resource_value(resource_updated_queue, "false", timeout=10)
 
-    # Trigger sideband lock — DoorLockDevice.js emits LockOperation (Lock) event
+    # Trigger sideband lock — the device's LockState attribute transitions to Locked
     result = matter_door_lock.sideband.send("lock")
     assert result["lockState"] == "locked"
 
-    # Barton should receive a resource update driven by the LockOperation event
+    # Barton receives the LockState attribute report and updates the resource (RESOURCE_UPDATED)
     wait_for_resource_value(resource_updated_queue, "true", timeout=10)

--- a/testing/test/door_lock_test.py
+++ b/testing/test/door_lock_test.py
@@ -35,7 +35,9 @@ from testing.utils.barton_utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.requires_matterjs
+pytestmark = [
+    pytest.mark.requires_matterjs,
+]
 
 
 def _commission_door_lock(default_environment, matter_door_lock):
@@ -124,9 +126,10 @@ def test_sideband_lock_triggers_barton_update(
 def test_locked_resource_seeded_on_commission(default_environment, matter_door_lock):
     """Verify that the locked resource is seeded with the correct initial value at commission.
 
-    The virtual door lock starts in the locked state. The seedFrom mapper runs inside
-    DoRegisterResources (before DEVICE_ADDED fires), so the value is baked directly into
-    createEndpointResource. Verify by reading the resource value directly after commission.
+    The virtual door lock starts in the locked state. The seed handler runs inside
+    DoRegisterDriverResources (before DEVICE_ADDED fires), so the value is baked
+    directly into createEndpointResource. Verify by reading the resource value
+    directly after commission.
     """
 
     lock = _commission_door_lock(default_environment, matter_door_lock)
@@ -217,13 +220,14 @@ def test_locked_resource_seeded_on_synchronize(default_environment, matter_door_
 
 
 def test_locked_resource_updated_by_event(default_environment, matter_door_lock):
-    """Verify that the locked resource updates when a LockOperation event is received.
+    """Verify that the locked resource updates when the LockState attribute changes.
 
-    Confirm the initial seeded value via direct read (the seedFrom mapper runs inside
-    DoRegisterResources and bakes the value in without emitting RESOURCE_UPDATED), then
-    trigger sideband unlock and verify the resource transitions to "false" via the
-    LockOperation event. Then lock and verify "true".
+    Confirm the initial seeded value via direct read (the seed handler runs inside
+    DoRegisterDriverResources and bakes the value in without emitting RESOURCE_UPDATED),
+    then trigger sideband unlock and verify the resource transitions to "false" via the
+    LockState attribute subscription report. Then lock and verify "true".
     """
+
     lock = _commission_door_lock(default_environment, matter_door_lock)
     client = default_environment.get_client()
 

--- a/testing/test/humidity_sensor_test.py
+++ b/testing/test/humidity_sensor_test.py
@@ -38,7 +38,9 @@ from testing.utils.barton_utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.requires_matterjs
+pytestmark = [
+    pytest.mark.requires_matterjs,
+]
 
 
 def test_commission_humidity_sensor(

--- a/testing/test/ikea_timmerflotte_test.py
+++ b/testing/test/ikea_timmerflotte_test.py
@@ -82,7 +82,7 @@ def test_commission_timmerflotte(
         ],
     )
 
-    # Virtual device defaults: temperature = 2550 (25.50°C), humidity = 5000 (50.00%)
+    # Virtual device defaults: temperature = 2550 (25.50°C), humidity = 5000 (50.00%) -> 50 whole percent
     wait_for_resource_value(temp_queue, "2550")
     wait_for_resource_value(hum_queue, "50")
 

--- a/testing/test/ikea_timmerflotte_test.py
+++ b/testing/test/ikea_timmerflotte_test.py
@@ -45,7 +45,9 @@ from testing.mocks.devices.matter.matter_ikea_timmerflotte import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.requires_matterjs
+pytestmark = [
+    pytest.mark.requires_matterjs,
+]
 
 
 # ================================================================
@@ -57,12 +59,17 @@ def test_commission_timmerflotte(
     default_environment, matter_ikea_timmerflotte
 ):
     """Commission an IKEA TIMMERFLOTTE sensor and verify both resources."""
+    client = default_environment.get_client()
+
+    # Register listeners before commissioning to catch initial subscription values
+    temp_queue = resource_update_listener(client, "temperature")
+    hum_queue = resource_update_listener(client, "humidity")
+
     device = commission_device(
         default_environment,
         matter_ikea_timmerflotte,
         "environmentalSensor",
     )
-    client = default_environment.get_client()
 
     assert_device_has_common_resources(
         client,
@@ -76,9 +83,6 @@ def test_commission_timmerflotte(
     )
 
     # Virtual device defaults: temperature = 2550 (25.50°C), humidity = 5000 (50.00%)
-    temp_queue = resource_update_listener(client, "temperature")
-    hum_queue = resource_update_listener(client, "humidity")
-
     wait_for_resource_value(temp_queue, "2550")
     wait_for_resource_value(hum_queue, "50")
 

--- a/testing/test/temperature_sensor_test.py
+++ b/testing/test/temperature_sensor_test.py
@@ -38,7 +38,9 @@ from testing.utils.barton_utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.requires_matterjs
+pytestmark = [
+    pytest.mark.requires_matterjs,
+]
 
 
 def test_commission_temperature_sensor(

--- a/testing/test/thermostat_test.py
+++ b/testing/test/thermostat_test.py
@@ -36,7 +36,9 @@ from testing.utils.barton_utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.requires_matterjs
+pytestmark = [
+    pytest.mark.requires_matterjs,
+]
 
 
 def _commission_thermostat(default_environment, matter_thermostat):

--- a/testing/test/thermostat_with_fan_test.py
+++ b/testing/test/thermostat_with_fan_test.py
@@ -35,7 +35,9 @@ from testing.utils.barton_utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.requires_matterjs
+pytestmark = [
+    pytest.mark.requires_matterjs,
+]
 
 
 def _commission_thermostat_with_fan(default_environment, matter_thermostat_with_fan):


### PR DESCRIPTION
Bundles dev-environment tweaks and SBMD v4 integration-test updates, plus a review fix hardening the supplement contract for seed handlers.

## Supplement contract fix

A CI failure exposed a timing bug: seed handlers could run before the device cache was populated, so declared supplements went missing and handlers hit undefined.

- `AddSupplements` now uses the handler's declaration as source of truth — every declared key is defined (its value, or null), never undefined.
- Add unit tests to verify

## Dev environment

- Add build-tree LD_LIBRARY_PATH to devcontainer and all launch configs so freshly compiled libraries are used without `make install`

## Integration tests & tooling

- Update validate-sbmd skill documentation for v4 workflow
- Update integration tests to match v4 driver resource naming
- Fix environment orchestrator for v4 spec file extension