### PR TITLE
feat(matter): add gated verbose Matter message tracing

### DIFF
--- a/build-matter.sh
+++ b/build-matter.sh
@@ -26,11 +26,12 @@
 set -e
 
 help() {
-    echo "Usage: $0 [-h] [-c <dir>] [-s] [-a]"
+    echo "Usage: $0 [-h] [-c <dir>] [-s] [-a] [-t]"
     echo "  -h  Display help"
     echo "  -c  Matter configuration directory"
     echo "  -s  Build with stack smash protection"
     echo "  -a  Build with address sanitizer"
+    echo "  -t  Build with Matter message tracing support (developer feature)"
 }
 
 MY_DIR=$(realpath $(dirname $0))
@@ -42,12 +43,13 @@ MATTER_REF=$(cat ${MY_DIR}/matter-version)
 
 BUILD_WITH_STACK_SMASH_PROTECTION=""
 BUILD_WITH_SANITIZER=""
+BUILD_WITH_MESSAGE_TRACING=""
 MATTER_CONF_DIR=""
 
 # Prevent building Java bits which we don't need/use. I couldn't find a better way.
 unset JAVA_HOME
 
-while getopts ":hc:sa" option; do
+while getopts ":hc:sat" option; do
     case $option in
     h)
         help
@@ -61,6 +63,9 @@ while getopts ":hc:sa" option; do
         ;;
     a)
         BUILD_WITH_SANITIZER="-a"
+        ;;
+    t)
+        BUILD_WITH_MESSAGE_TRACING="-t"
         ;;
     esac
 done
@@ -83,7 +88,7 @@ else
     ./scripts/checkout_submodules.py --shallow --platform linux
 
     git am ${MY_DIR}/third_party/matter/barton-library/patches/*.patch || (git am --abort && git reset --hard ${MATTER_REF} && exit 1)
-    ${MY_DIR}/third_party/matter/barton-library/linux/build.sh -o ${MATTER_INSTALL_DIR} -c ${MATTER_CONF_DIR} ${BUILD_WITH_STACK_SMASH_PROTECTION} ${BUILD_WITH_SANITIZER}
+    ${MY_DIR}/third_party/matter/barton-library/linux/build.sh -o ${MATTER_INSTALL_DIR} -c ${MATTER_CONF_DIR} ${BUILD_WITH_STACK_SMASH_PROTECTION} ${BUILD_WITH_SANITIZER} ${BUILD_WITH_MESSAGE_TRACING}
 
     cd ${MATTER_BUILD_DIR}
     git reset --hard ${MATTER_REF}

--- a/config/cmake/options.cmake
+++ b/config/cmake/options.cmake
@@ -167,6 +167,9 @@ bcore_option(NAME BCORE_MATTER_USE_DEFAULT_COMMISSIONABLE_DATA
 bcore_option(NAME BCORE_MATTER_ENABLE_OTA_PROVIDER
            DEFINITION BARTON_CONFIG_MATTER_ENABLE_OTA_PROVIDER
            DESCRIPTION "Enable OTA provider for Matter and configure devices with OTA Requestor cluster")
+bcore_option(NAME BCORE_MATTER_MESSAGE_TRACING
+           DEFINITION BARTON_CONFIG_MATTER_MESSAGE_TRACING
+           DESCRIPTION "Developer feature: enable verbose Matter message tracing (inbound/outbound messages logged as JSON via ChipLog). Automatically builds the Matter library with tracing support. Not for production use.")
 bcore_option(NAME BCORE_MATTER_VALIDATE_SCHEMAS
            DEFINITION BARTON_CONFIG_MATTER_VALIDATE_SCHEMAS
            DESCRIPTION "Enable validation of SBMD schemas"

--- a/core/src/subsystems/matter/Matter.cpp
+++ b/core/src/subsystems/matter/Matter.cpp
@@ -83,6 +83,11 @@ extern "C" {
 
 #include <platform/Linux/KeyValueStoreManagerImpl.h>
 
+#ifdef BARTON_CONFIG_MATTER_MESSAGE_TRACING
+#include <tracing/json/json_tracing.h>
+#include <tracing/registry.h>
+#endif
+
 #include <lib/support/TestGroupData.h>
 
 #include <lib/core/NodeId.h>
@@ -162,6 +167,13 @@ namespace
     std::optional<ThreadBorderRouterManagement::ServerInstance> threadBorderRouterManagementServer;
     EndpointId threadBorderRouterManagementServerEndpointId = UINT16_MAX;
 #endif // ZCL_USING_THREAD_BORDER_ROUTER_MANAGEMENT_CLUSTER_SERVER
+
+#ifdef BARTON_CONFIG_MATTER_MESSAGE_TRACING
+    // Developer-only Matter message trace backend. Emits every inbound/outbound
+    // Matter message (hex + fully-decoded TLV) as a JSON record via ChipLog.
+    // Registered in Matter::Init() and unregistered in Matter::StackThreadProc().
+    chip::Tracing::Json::JsonBackend matterMessageTraceBackend;
+#endif
 } // namespace
 
 Matter::Matter() : groupDataProvider(kMaxGroupsPerFabric, kMaxGroupKeysPerFabric)
@@ -255,6 +267,16 @@ bool Matter::Init(uint64_t accountId, std::string &&attestationTrustStorePath, c
         icError("InitChipStack failed: %s", err.AsString());
         return false;
     }
+
+#ifdef BARTON_CONFIG_MATTER_MESSAGE_TRACING
+    // Developer feature: register the SDK-wide Matter message trace backend. Every
+    // inbound/outbound Matter message is logged (hex + fully-decoded TLV) as a JSON
+    // record via ChipLog. Unregistered in StackThreadProc() once the event loop stops.
+    // WARNING: this is high volume and will noticeably slow the stack; it is gated
+    // behind BCORE_MATTER_MESSAGE_TRACING and intended for debugging only.
+    icWarn("Matter message tracing is ENABLED (developer feature). Expect verbose, high-volume logging.");
+    chip::Tracing::Register(matterMessageTraceBackend);
+#endif
 
     if (!GetBartonDeviceInstanceInfoProvider().ValidateProperties())
     {
@@ -445,6 +467,11 @@ void Matter::StackThreadProc()
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
+
+#ifdef BARTON_CONFIG_MATTER_MESSAGE_TRACING
+    // Backends MUST be unregistered before exit, with the Matter stack lock held.
+    chip::Tracing::Unregister(matterMessageTraceBackend);
+#endif
 
     auto &server = chip::Server::GetInstance();
     server.Shutdown();

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -94,3 +94,29 @@ for more information on these PATHs and how to set them.
    1. For debugging pure python: `run <path-to-python-file>`
    2. For debugging a pytest `run -m pytest <path-to-python-file>`. NOTE: If Barton has been compiled with Address Sanitizer,
       you must set the LD_PRELOAD variable first with `set env LD_PRELOAD=<path-to-libasan.so>`.
+
+## Matter Message Tracing
+
+For debugging the Matter stack, Barton can log every inbound and outbound Matter message as a JSON
+record (hex payload plus fully-decoded TLV) through the normal ChipLog output. This is a
+developer-only feature: it is off by default, very high volume, and will noticeably slow the stack.
+Do not enable it in production.
+
+Enabling it is a single build option:
+
+```
+./build.sh -DBCORE_MATTER_MESSAGE_TRACING=ON
+```
+
+When this option is ON, CMake automatically builds the Matter library with tracing support
+(passing `-t` to `build-matter.sh`) and compiles the trace backend into the core. If a Matter build
+already exists under `build/matter` (built without tracing), delete it first so it is rebuilt:
+
+```
+rm -rf build/matter build/matter-install
+./build.sh -DBCORE_MATTER_MESSAGE_TRACING=ON
+```
+
+When enabled, Barton logs a warning at startup and the per-message JSON trace records appear inline
+with the rest of the logs. Turn the feature off again with `./build.sh -d -DBCORE_MATTER_MESSAGE_TRACING=OFF`
+(and delete `build/matter` to drop tracing support from the library).

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -51,8 +51,13 @@ if (BCORE_MATTER AND NOT BCORE_MATTER_SKIP_SDK)
             set(MATTER_ASAN_ARG "-a")
         endif()
 
+        # Forward Matter message tracing arg to building matter (developer feature)
+        if (BCORE_MATTER_MESSAGE_TRACING)
+            set(MATTER_TRACING_ARG "-t")
+        endif()
+
         # TODO: This config directory should be the same as what is available at runtime via providers. Perhaps this should be a public build option
-        set(MATTER_BUILD_COMMAND ./build-matter.sh -c $ENV{HOME}/.brtn-ds/matter ${MATTER_SSP_ARG} ${MATTER_ASAN_ARG})
+        set(MATTER_BUILD_COMMAND ./build-matter.sh -c $ENV{HOME}/.brtn-ds/matter ${MATTER_SSP_ARG} ${MATTER_ASAN_ARG} ${MATTER_TRACING_ARG})
 
         execute_process(
             COMMAND ${MATTER_BUILD_COMMAND}

--- a/third_party/matter/barton-library/linux/BUILD.gn
+++ b/third_party/matter/barton-library/linux/BUILD.gn
@@ -32,6 +32,7 @@ import("//build_overrides/chip.gni")
 
 import("//build/chip/tools.gni")
 import("//src/app/chip_data_model.gni")
+import("//src/tracing/tracing_args.gni")
 
 project_dir = "./.."
 
@@ -49,6 +50,13 @@ static_library("barton") {
     "//src/setup_payload",
     "//src/lib/support/jsontlv",
   ]
+
+  # Developer feature: the JSON tracing backend is only available (and only
+  # linkable) when the SDK is built with tracing support. Gated so a default
+  # library build links nothing extra. See build-matter.sh -t / build.sh -t.
+  if (matter_enable_tracing_support) {
+    public_deps += [ "//src/tracing/json" ]
+  }
 
   output_name = "libBartonMatter"
   complete_static_lib = true

--- a/third_party/matter/barton-library/linux/build.sh
+++ b/third_party/matter/barton-library/linux/build.sh
@@ -30,12 +30,13 @@
 set -e
 
 help() {
-    echo "Usage: $0 [-h] [-o <dir>] [-c <dir>] [-s] [-a]"
+    echo "Usage: $0 [-h] [-o <dir>] [-c <dir>] [-s] [-a] [-t]"
     echo "  -h  Display help"
     echo "  -o  Output directory"
     echo "  -c  Matter configuration directory"
     echo "  -s  Build with stack smash protection"
     echo "  -a  Build with address sanitizer"
+    echo "  -t  Build with Matter message tracing support (developer feature)"
 }
 
 MY_DIR=$(dirname $(readlink -f $0))
@@ -47,8 +48,9 @@ OUT_DIR=$MY_DIR/out
 MATTER_CONF_DIR="/tmp"
 BUILD_WITH_STACK_SMASH_PROTECTION=false
 BUILD_WITH_SANITIZER=false
+BUILD_WITH_MESSAGE_TRACING=false
 
-while getopts ":ho:c:sa" option; do
+while getopts ":ho:c:sat" option; do
     case $option in
     h)
         help
@@ -65,6 +67,9 @@ while getopts ":ho:c:sa" option; do
         ;;
     a)
         BUILD_WITH_SANITIZER=true
+        ;;
+    t)
+        BUILD_WITH_MESSAGE_TRACING=true
         ;;
     esac
 done
@@ -118,6 +123,14 @@ echo "Generating BartonProjectConfig"
 python3 $MY_DIR/configure_project_config.py $MY_DIR/BartonProjectConfig.h.in $PROJECT_CONFIG_DIR/BartonProjectConfig.h "CHIP_BARTON_CONF_DIR=$MATTER_CONF_DIR" "BARTON_CORE_VERSION=$BARTON_CORE_VERSION"
 
 GN_ARGS="chip_project_config_include_dirs=$PROJECT_INCLUDE_DIRS target_cflags_c=$CFLAGS target_cflags_cc=$CXXFLAGS target_ldflags=$LDFLAGS"
+
+# Developer feature: enable SDK-wide Matter message tracing. This links the JSON
+# tracing backend and turns on full hex + decoded-TLV payload logging. Off by
+# default; must be matched by BCORE_MATTER_MESSAGE_TRACING in the core build.
+if [ "$BUILD_WITH_MESSAGE_TRACING" = true ]; then
+    echo "Building Matter with message tracing support (developer feature)"
+    GN_ARGS+=" matter_enable_tracing_support=true matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_trace_config=\"//src/tracing/none\""
+fi
 
 echo "Running: gn --root=$CHIP_ROOT --root-target=$MY_DIR --dotfile=$MY_DIR/.gn gen --check --fail-on-unused-arg --args=\"$GN_ARGS\" $OUT_DIR"
 gn --root=$CHIP_ROOT --root-target=$MY_DIR --dotfile=$MY_DIR/.gn gen --check --fail-on-unused-arg --args="$GN_ARGS" $OUT_DIR


### PR DESCRIPTION
Add BCORE_MATTER_MESSAGE_TRACING (default OFF), a developer-only build option that logs every inbound/outbound Matter message as a JSON record (hex payload + fully-decoded TLV) inline via ChipLog.

- config/cmake/options.cmake: new bcore_option -> BARTON_CONFIG_MATTER_MESSAGE_TRACING
- Matter.cpp: register a JsonBackend on init and unregister on stop, guarded by the flag
- third_party/CMakeLists.txt: forward -t to build-matter.sh when the option is ON so a single build configures both the SDK and core
- build-matter.sh / barton-library build.sh: -t enables the tracing GN args (matter_enable_tracing_support + payload hex/decode)
- barton-library BUILD.gn: gate the //src/tracing/json dep on matter_enable_tracing_support
- docs/DEBUGGING.md: document the feature