### PR TITLE
fix(install): avoid LSAN hang in stub generation

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -429,6 +429,12 @@ if (BCORE_GEN_GIR)
         elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             set(ASAN_LD_PRELOAD "LD_PRELOAD=$(gcc -print-file-name=libasan.so)")
         endif()
+
+        # The pygobject-stubs generator imports the instrumented BartonCore
+        # library and exits immediately. In ASAN builds, LSAN teardown can hang
+        # during that short-lived import-only path, so disable leak detection
+        # for this post-install helper just as we already do for GIR generation.
+        set(ASAN_STUBS_ENV "LSAN_OPTIONS=detect_leaks=0")
     endif()
 
     configure_file(gen_pygobject_stubs.in gen_pygobject_stubs @ONLY)

--- a/core/gen_pygobject_stubs.in
+++ b/core/gen_pygobject_stubs.in
@@ -43,7 +43,7 @@ STUBS_DIR=${STUBS_PACKAGE_DIR}/gi-stubs/repository
 STUB_FILE=${STUBS_DIR}/${GIR_NAME}.pyi
 
 echo "Running: LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${BCORE_LIBRARY_LOCATION} python3 ${GENERATE_SCRIPT} ${GIR_NAME} ${GIR_VERSION} -u ${STUB_FILE}"
-echo "Output supressed for brevity. See ${OUTPUT_FILE} for output. Note: failure cases may not be detectable if script does not call sys.exit() with error codes."
+echo "Output suppressed for brevity. See ${OUTPUT_FILE} for output. Note: failure cases may not be detectable if script does not call sys.exit() with error codes."
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${BCORE_LIBRARY_LOCATION} @ASAN_STUBS_ENV@ @ASAN_LD_PRELOAD@ python3 ${GENERATE_SCRIPT} ${GIR_NAME} ${GIR_VERSION} -u ${STUB_FILE} >${OUTPUT_FILE} 2>&1
 
 if [ $? -ne 0 ]; then

--- a/core/gen_pygobject_stubs.in
+++ b/core/gen_pygobject_stubs.in
@@ -44,7 +44,7 @@ STUB_FILE=${STUBS_DIR}/${GIR_NAME}.pyi
 
 echo "Running: LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${BCORE_LIBRARY_LOCATION} python3 ${GENERATE_SCRIPT} ${GIR_NAME} ${GIR_VERSION} -u ${STUB_FILE}"
 echo "Output supressed for brevity. See ${OUTPUT_FILE} for output. Note: failure cases may not be detectable if script does not call sys.exit() with error codes."
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${BCORE_LIBRARY_LOCATION} @ASAN_LD_PRELOAD@ python3 ${GENERATE_SCRIPT} ${GIR_NAME} ${GIR_VERSION} -u ${STUB_FILE} >${OUTPUT_FILE} 2>&1
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${BCORE_LIBRARY_LOCATION} @ASAN_STUBS_ENV@ @ASAN_LD_PRELOAD@ python3 ${GENERATE_SCRIPT} ${GIR_NAME} ${GIR_VERSION} -u ${STUB_FILE} >${OUTPUT_FILE} 2>&1
 
 if [ $? -ne 0 ]; then
     echo "Failed to generate pygobject stubs. Refer to ${OUTPUT_FILE} for more information."


### PR DESCRIPTION
The post-install pygobject-stubs helper imports the ASAN-instrumented BartonCore library and exits immediately. In ASAN builds, LSAN teardown can hang in that short-lived import path, which leaves make install stuck after typelib installation.

Disable leak detection for the stub-generation helper while keeping the ASAN preload in place so the instrumented library still loads. This matches the existing GIR-generation environment and lets the install-time stub generation step exit cleanly.