### PR TITLE
feat(matter): add large-payload TCP transport capability with MRP fallback

### DIFF
--- a/core/deviceDrivers/matter/MatterDevice.cpp
+++ b/core/deviceDrivers/matter/MatterDevice.cpp
@@ -405,7 +405,12 @@ bool MatterDevice::SendCommandFromTlv(std::forward_list<std::promise<bool>> &pro
     }
 
     bool isTimedRequest = timedInvokeTimeoutMs.has_value();
-    auto commandSender = std::make_unique<chip::app::CommandSender>(this, &exchangeMgr, isTimedRequest);
+
+    // Allow large (TCP) payloads when the session supports them so large commands do not fail
+    // to serialize against the MRP/UDP single-message limit.
+    bool allowLargePayload = sessionHandle->AllowsLargePayload();
+    auto commandSender =
+        std::make_unique<chip::app::CommandSender>(this, &exchangeMgr, isTimedRequest, false, allowLargePayload);
 
     if (!commandSender)
     {
@@ -531,7 +536,13 @@ bool MatterDevice::SendCommandWithCallbacks(chip::ClusterId clusterId,
     }
 
     bool isTimedRequest = timedInvokeTimeoutMs.has_value();
-    auto commandSender = std::make_unique<chip::app::CommandSender>(this, &exchangeMgr, isTimedRequest);
+
+    // Allow large (TCP) payloads when the session supports them. Without this the CommandSender
+    // caps its buffer at the MRP/UDP single-message limit (~1280 bytes), which makes large
+    // commands such as a WebRTC ProvideOffer SDP fail to serialize.
+    bool allowLargePayload = sessionHandle->AllowsLargePayload();
+    auto commandSender =
+        std::make_unique<chip::app::CommandSender>(this, &exchangeMgr, isTimedRequest, false, allowLargePayload);
 
     if (!commandSender)
     {
@@ -564,6 +575,10 @@ bool MatterDevice::SendCommandWithCallbacks(chip::ClusterId clusterId,
 
     if (err != CHIP_NO_ERROR)
     {
+        icError("Failed to enter TLV container for deferred command cluster 0x%x cmd 0x%x: %s",
+                clusterId,
+                commandId,
+                err.AsString());
         return false;
     }
 
@@ -573,12 +588,22 @@ bool MatterDevice::SendCommandWithCallbacks(chip::ClusterId clusterId,
 
         if (err != CHIP_NO_ERROR)
         {
+            // A buffer-too-small/no-memory error here typically means the payload exceeds what the
+            // session's transport allows (e.g. a large SDP over an MRP/UDP session that is not
+            // large-payload capable). Establishing the session with a large-payload (TCP) transport
+            // resolves it.
+            icError("Failed to copy TLV element for deferred command cluster 0x%x cmd 0x%x "
+                    "(payload may exceed the session's transport limit): %s",
+                    clusterId,
+                    commandId,
+                    err.AsString());
             return false;
         }
     }
 
     if (err != CHIP_END_OF_TLV)
     {
+        icError("Malformed TLV for deferred command cluster 0x%x cmd 0x%x: %s", clusterId, commandId, err.AsString());
         return false;
     }
 
@@ -589,6 +614,13 @@ bool MatterDevice::SendCommandWithCallbacks(chip::ClusterId clusterId,
 
     if (err != CHIP_NO_ERROR)
     {
+        // As with CopyElement above, this commonly indicates the payload exceeds the session's
+        // transport limit; a large-payload (TCP) session is required for oversized commands.
+        icError("Failed to finish deferred command cluster 0x%x cmd 0x%x "
+                "(payload may exceed the session's transport limit): %s",
+                clusterId,
+                commandId,
+                err.AsString());
         return false;
     }
 

--- a/core/deviceDrivers/matter/MatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterDeviceDriver.cpp
@@ -911,10 +911,7 @@ void MatterDeviceDriver::AbortDeviceConnectionAttempt(chip::Callback::Callback<O
     });
 }
 
-bool MatterDeviceDriver::ConnectAndExecute(const std::string &deviceId,
-                                           connect_work_cb &&work,
-                                           uint16_t timeoutSeconds,
-                                           chip::TransportPayloadCapability transportPayloadCapability)
+bool MatterDeviceDriver::ConnectAndExecute(const std::string &deviceId, connect_work_cb &&work, uint16_t timeoutSeconds)
 {
     icDebug();
 
@@ -951,39 +948,28 @@ bool MatterDeviceDriver::ConnectAndExecute(const std::string &deviceId,
     chip::Callback::Callback<OnDeviceConnected> successCb(OnMatterDeviceConnectionSuccess,
                                                           static_cast<void *>(&workWrapper));
 
-    // SDK event size limitations (LambdaBridge caps captures at 24 bytes) prevent directly
-    // capturing too many objects. Bundle everything the scheduled task needs into a single
-    // local context and capture just a pointer to it. The context outlives the async task
-    // because this function blocks on connectFuture until the work completes or times out.
-    // connectPromise is directly pointed at in failCb.mContext, so it is indirectly
-    // captured via failCb.
-    struct ConnectScheduleContext
-    {
-        chip::NodeId nodeId;
-        chip::Callback::Callback<OnDeviceConnected> *successCb;
-        chip::Callback::Callback<OnDeviceConnectionFailure> *failCb;
-        chip::TransportPayloadCapability transportPayloadCapability;
-    };
+    // Initiate the connection on the Matter thread. GetConnectedDevice is non-blocking (it starts
+    // the connection and returns immediately; successCb/failCb fire later), so run it synchronously
+    // under RunOnMatterSync rather than deferring it with ScheduleLambda. Running it synchronously
+    // guarantees the connection is never initiated after ConnectAndExecute has returned, so a
+    // timed-out call can never later invoke GetConnectedDevice with dangling callback pointers.
+    // RunOnMatterSync blocks until the work returns, keeping the by-reference captures (including
+    // the stack-owned callbacks) alive for its whole duration, and its std::function work is not
+    // subject to the LambdaBridge 24-byte capture limit that applies to ScheduleLambda directly.
+    chip::NodeId nodeId = Subsystem::Matter::UuidToNodeId(deviceId);
+    // Seed with an error so that if RunOnMatterSync fails to schedule the work (e.g. the stack goes
+    // down between the IsRunning() check above and this call), getConnectedErr stays non-OK and we
+    // fail fast below instead of waiting out the full connect timeout on a promise that would never
+    // be satisfied.
+    CHIP_ERROR getConnectedErr = CHIP_ERROR_INCORRECT_STATE;
 
-    ConnectScheduleContext scheduleContext {
-        Subsystem::Matter::UuidToNodeId(deviceId), &successCb, &failCb, transportPayloadCapability};
-
-    auto err = chip::DeviceLayer::SystemLayer().ScheduleLambda([&scheduleContext]() {
-        CHIP_ERROR getConnectedErr =
-            Matter::GetInstance().GetCommissioner()->GetConnectedDevice(scheduleContext.nodeId,
-                                                                        scheduleContext.successCb,
-                                                                        scheduleContext.failCb,
-                                                                        scheduleContext.transportPayloadCapability);
-        if (getConnectedErr != CHIP_NO_ERROR)
-        {
-            icError("Failed to start device connection: %s", getConnectedErr.AsString());
-            static_cast<std::promise<bool> *>(scheduleContext.failCb->mContext)->set_value(false);
-        }
+    RunOnMatterSync([&]() {
+        getConnectedErr = Matter::GetInstance().GetCommissioner()->GetConnectedDevice(nodeId, &successCb, &failCb);
     });
 
-    if (err != CHIP_NO_ERROR)
+    if (getConnectedErr != CHIP_NO_ERROR)
     {
-        icError("Failed to schedule connect task: %s", err.AsString());
+        icError("Failed to start device connection: %s", getConnectedErr.AsString());
         return false;
     }
 

--- a/core/deviceDrivers/matter/MatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterDeviceDriver.cpp
@@ -949,13 +949,15 @@ bool MatterDeviceDriver::ConnectAndExecute(const std::string &deviceId, connect_
                                                           static_cast<void *>(&workWrapper));
 
     // Initiate the connection on the Matter thread. GetConnectedDevice is non-blocking (it starts
-    // the connection and returns immediately; successCb/failCb fire later), so run it synchronously
-    // under RunOnMatterSync rather than deferring it with ScheduleLambda. Running it synchronously
-    // guarantees the connection is never initiated after ConnectAndExecute has returned, so a
-    // timed-out call can never later invoke GetConnectedDevice with dangling callback pointers.
-    // RunOnMatterSync blocks until the work returns, keeping the by-reference captures (including
-    // the stack-owned callbacks) alive for its whole duration, and its std::function work is not
-    // subject to the LambdaBridge 24-byte capture limit that applies to ScheduleLambda directly.
+    // the connection and returns immediately; successCb/failCb fire later). RunOnMatterSync marshals
+    // this onto the Matter thread (via ScheduleLambda) but blocks until it has run, so
+    // GetConnectedDevice is guaranteed to execute before ConnectAndExecute can proceed or time out.
+    // That ordering is the point: unlike a bare ScheduleLambda whose deferred work could run *after*
+    // ConnectAndExecute has returned, the connection is never initiated once we are past this call,
+    // so a timed-out call can never later invoke GetConnectedDevice with dangling callback pointers.
+    // Blocking here also keeps the by-reference captures (including the stack-owned callbacks) alive
+    // for the whole call, and RunOnMatterSync's std::function work is not subject to the LambdaBridge
+    // 24-byte capture limit that applies to using ScheduleLambda directly.
     chip::NodeId nodeId = Subsystem::Matter::UuidToNodeId(deviceId);
     // Seed with an error so that if RunOnMatterSync fails to schedule the work (e.g. the stack goes
     // down between the IsRunning() check above and this call), getConnectedErr stays non-OK and we

--- a/core/deviceDrivers/matter/MatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/MatterDeviceDriver.cpp
@@ -911,7 +911,10 @@ void MatterDeviceDriver::AbortDeviceConnectionAttempt(chip::Callback::Callback<O
     });
 }
 
-bool MatterDeviceDriver::ConnectAndExecute(const std::string &deviceId, connect_work_cb &&work, uint16_t timeoutSeconds)
+bool MatterDeviceDriver::ConnectAndExecute(const std::string &deviceId,
+                                           connect_work_cb &&work,
+                                           uint16_t timeoutSeconds,
+                                           chip::TransportPayloadCapability transportPayloadCapability)
 {
     icDebug();
 
@@ -948,19 +951,33 @@ bool MatterDeviceDriver::ConnectAndExecute(const std::string &deviceId, connect_
     chip::Callback::Callback<OnDeviceConnected> successCb(OnMatterDeviceConnectionSuccess,
                                                           static_cast<void *>(&workWrapper));
 
-    // SDK event size limitations prevent directly capturing too many objects.
+    // SDK event size limitations (LambdaBridge caps captures at 24 bytes) prevent directly
+    // capturing too many objects. Bundle everything the scheduled task needs into a single
+    // local context and capture just a pointer to it. The context outlives the async task
+    // because this function blocks on connectFuture until the work completes or times out.
     // connectPromise is directly pointed at in failCb.mContext, so it is indirectly
     // captured via failCb.
+    struct ConnectScheduleContext
+    {
+        chip::NodeId nodeId;
+        chip::Callback::Callback<OnDeviceConnected> *successCb;
+        chip::Callback::Callback<OnDeviceConnectionFailure> *failCb;
+        chip::TransportPayloadCapability transportPayloadCapability;
+    };
 
-    auto err = chip::DeviceLayer::SystemLayer().ScheduleLambda([&deviceId, &successCb, &failCb]() {
-        auto nodeId = Subsystem::Matter::UuidToNodeId(deviceId);
+    ConnectScheduleContext scheduleContext {
+        Subsystem::Matter::UuidToNodeId(deviceId), &successCb, &failCb, transportPayloadCapability};
 
+    auto err = chip::DeviceLayer::SystemLayer().ScheduleLambda([&scheduleContext]() {
         CHIP_ERROR getConnectedErr =
-            Matter::GetInstance().GetCommissioner()->GetConnectedDevice(nodeId, &successCb, &failCb);
+            Matter::GetInstance().GetCommissioner()->GetConnectedDevice(scheduleContext.nodeId,
+                                                                        scheduleContext.successCb,
+                                                                        scheduleContext.failCb,
+                                                                        scheduleContext.transportPayloadCapability);
         if (getConnectedErr != CHIP_NO_ERROR)
         {
             icError("Failed to start device connection: %s", getConnectedErr.AsString());
-            static_cast<std::promise<bool> *>(failCb.mContext)->set_value(false);
+            static_cast<std::promise<bool> *>(scheduleContext.failCb->mContext)->set_value(false);
         }
     });
 

--- a/core/deviceDrivers/matter/MatterDeviceDriver.h
+++ b/core/deviceDrivers/matter/MatterDeviceDriver.h
@@ -190,7 +190,11 @@ namespace barton
          * @return true When all work has successfully completed
          * @return false
          */
-        bool ConnectAndExecute(const std::string &deviceId, connect_work_cb &&work, uint16_t timeoutSeconds);
+        bool ConnectAndExecute(const std::string &deviceId,
+                               connect_work_cb &&work,
+                               uint16_t timeoutSeconds,
+                               chip::TransportPayloadCapability transportPayloadCapability =
+                                   chip::TransportPayloadCapability::kLargePayloadWithMRPFallback);
 
         /**
          * @brief Used by ConnectAndExecute to abort a connection attempt. This guarantees

--- a/core/deviceDrivers/matter/MatterDeviceDriver.h
+++ b/core/deviceDrivers/matter/MatterDeviceDriver.h
@@ -190,11 +190,7 @@ namespace barton
          * @return true When all work has successfully completed
          * @return false
          */
-        bool ConnectAndExecute(const std::string &deviceId,
-                               connect_work_cb &&work,
-                               uint16_t timeoutSeconds,
-                               chip::TransportPayloadCapability transportPayloadCapability =
-                                   chip::TransportPayloadCapability::kLargePayloadWithMRPFallback);
+        bool ConnectAndExecute(const std::string &deviceId, connect_work_cb &&work, uint16_t timeoutSeconds);
 
         /**
          * @brief Used by ConnectAndExecute to abort a connection attempt. This guarantees

--- a/core/src/subsystems/matter/DeviceDataCache.cpp
+++ b/core/src/subsystems/matter/DeviceDataCache.cpp
@@ -121,13 +121,14 @@ std::future<bool> DeviceDataCache::Start()
         [](intptr_t arg) {
             auto *self = reinterpret_cast<DeviceDataCache *>(arg);
 
-            if (self->controller->GetConnectedDevice(barton::Subsystem::Matter::UuidToNodeId(self->deviceUuid),
+            CHIP_ERROR err =
+                self->controller->GetConnectedDevice(barton::Subsystem::Matter::UuidToNodeId(self->deviceUuid),
                                                      &self->mOnDeviceConnectedCallback,
-                                                     &self->mOnDeviceConnectionFailureCallback,
-                                                     chip::TransportPayloadCapability::kLargePayloadWithMRPFallback) !=
-                CHIP_NO_ERROR)
+                                                     &self->mOnDeviceConnectionFailureCallback);
+
+            if (err != CHIP_NO_ERROR)
             {
-                icError("Failed to start device connection");
+                icError("Failed to start device connection: %s", err.AsString());
                 std::lock_guard<std::mutex> lock(self->startupPromiseMutex);
                 if (self->startupPromise)
                 {

--- a/core/src/subsystems/matter/DeviceDataCache.cpp
+++ b/core/src/subsystems/matter/DeviceDataCache.cpp
@@ -123,7 +123,9 @@ std::future<bool> DeviceDataCache::Start()
 
             if (self->controller->GetConnectedDevice(barton::Subsystem::Matter::UuidToNodeId(self->deviceUuid),
                                                      &self->mOnDeviceConnectedCallback,
-                                                     &self->mOnDeviceConnectionFailureCallback) != CHIP_NO_ERROR)
+                                                     &self->mOnDeviceConnectionFailureCallback,
+                                                     chip::TransportPayloadCapability::kLargePayloadWithMRPFallback) !=
+                CHIP_NO_ERROR)
             {
                 icError("Failed to start device connection");
                 std::lock_guard<std::mutex> lock(self->startupPromiseMutex);
@@ -734,6 +736,14 @@ void DeviceDataCache::OnSubscriptionEstablished(chip::SubscriptionId aSubscripti
 
     // Ensure that, once a subscription is established, the naturally negotiated liveness timeout is used
     readClient->OverrideLivenessTimeout(chip::System::Clock::kZero);
+
+    // Forward to the registered callback (e.g. MatterDevice::CacheCallback) so it can react to
+    // subscription establishment, such as caching cluster feature maps now that the priming
+    // report has populated the cache.
+    if (callback)
+    {
+        callback->OnSubscriptionEstablished(aSubscriptionId);
+    }
 }
 
 void DeviceDataCache::OnError(CHIP_ERROR aError)

--- a/third_party/matter/barton-library/linux/BartonProjectConfig.h.in
+++ b/third_party/matter/barton-library/linux/BartonProjectConfig.h.in
@@ -48,6 +48,11 @@
 #define INET_CONFIG_NUM_TCP_ENDPOINTS 50
 #define INET_CONFIG_NUM_UDP_ENDPOINTS 50
 
+// Allow as many concurrent active TCP connections as we have TCP endpoints. The Matter default of 4
+// is far smaller than our secure-session pool, and since we prefer TCP (kLargePayloadWithMRPFallback)
+// for connections, a low cap would force otherwise-TCP-capable peers onto UDP once 4 were in use.
+#define CHIP_CONFIG_MAX_ACTIVE_TCP_CONNECTIONS 50
+
 #define FATCONFDIR           CHIP_BARTON_CONF_DIR // CHIP Factory Config
 #define SYSCONFDIR           CHIP_BARTON_CONF_DIR // CHIP Sys Config
 #define LOCALSTATEDIR        CHIP_BARTON_CONF_DIR // CHIP Counters Config

--- a/third_party/matter/barton-library/patches/0003-transport-add-kLargePayloadWithMRPFallback-capabilit.patch
+++ b/third_party/matter/barton-library/patches/0003-transport-add-kLargePayloadWithMRPFallback-capabilit.patch
@@ -1,5 +1,5 @@
 From c899104f1093461e52a36d0718f5a579132ae6fb Mon Sep 17 00:00:00 2001
-From: Barton <barton@rdkcentral.com>
+From: Christian Leithner <christian_leithner@comcast.com>
 Date: Wed, 15 Jul 2026 18:20:09 +0000
 Subject: [PATCH] transport: add kLargePayloadWithMRPFallback capability
 
@@ -13,10 +13,11 @@ SDP) without breaking connections to UDP-only devices.
 - OperationalSessionSetup: establish over TCP when supportsTcpServer, else
   leave the default MRP/UDP transport.
 ---
- src/app/OperationalSessionSetup.cpp |  9 +++++++++
- src/transport/SessionManager.cpp    | 20 +++++++++++++++++++-
- src/transport/SessionManager.h      |  5 ++++-
- 3 files changed, 32 insertions(+), 2 deletions(-)
+ src/app/OperationalSessionSetup.cpp   |  9 +++++++++
+ src/controller/CHIPDeviceController.h |  4 ++--
+ src/transport/SessionManager.cpp      | 20 +++++++++++++++++++-
+ src/transport/SessionManager.h        |  5 ++++-
+ 4 files changed, 34 insertions(+), 4 deletions(-)
 
 diff --git a/src/app/OperationalSessionSetup.cpp b/src/app/OperationalSessionSetup.cpp
 index 5135e158..718a1f3a 100644
@@ -38,6 +39,28 @@ index 5135e158..718a1f3a 100644
  #endif
  
      mCASEClient = mClientPool->Allocate();
+diff --git a/src/controller/CHIPDeviceController.h b/src/controller/CHIPDeviceController.h
+index bd530b87..91bf7c34 100644
+--- a/src/controller/CHIPDeviceController.h
++++ b/src/controller/CHIPDeviceController.h
+@@ -256,7 +256,7 @@ public:
+     virtual CHIP_ERROR
+     GetConnectedDevice(NodeId peerNodeId, Callback::Callback<OnDeviceConnected> * onConnection,
+                        Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+-                       TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload)
++                       TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kLargePayloadWithMRPFallback)
+     {
+         VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+         mSystemState->CASESessionMgr()->FindOrEstablishSession(ScopedNodeId(peerNodeId, GetFabricIndex()), onConnection, onFailure,
+@@ -284,7 +284,7 @@ public:
+     CHIP_ERROR
+     GetConnectedDevice(NodeId peerNodeId, Callback::Callback<OnDeviceConnected> * onConnection,
+                        chip::Callback::Callback<OperationalSessionSetup::OnSetupFailure> * onSetupFailure,
+-                       TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload)
++                       TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kLargePayloadWithMRPFallback)
+     {
+         VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+         mSystemState->CASESessionMgr()->FindOrEstablishSession(ScopedNodeId(peerNodeId, GetFabricIndex()), onConnection,
 diff --git a/src/transport/SessionManager.cpp b/src/transport/SessionManager.cpp
 index ecd67f8a..bfc3da37 100644
 --- a/src/transport/SessionManager.cpp

--- a/third_party/matter/barton-library/patches/0003-transport-add-kLargePayloadWithMRPFallback-capabilit.patch
+++ b/third_party/matter/barton-library/patches/0003-transport-add-kLargePayloadWithMRPFallback-capabilit.patch
@@ -1,0 +1,100 @@
+From c899104f1093461e52a36d0718f5a579132ae6fb Mon Sep 17 00:00:00 2001
+From: Barton <barton@rdkcentral.com>
+Date: Wed, 15 Jul 2026 18:20:09 +0000
+Subject: [PATCH] transport: add kLargePayloadWithMRPFallback capability
+
+Add a TransportPayloadCapability that prefers a large-payload (TCP) session
+but transparently falls back to MRP/UDP when the peer does not advertise TCP
+server support, instead of failing the connection like kLargePayload does.
+This lets a controller request TCP for potentially large payloads (e.g. WebRTC
+SDP) without breaking connections to UDP-only devices.
+
+- SessionManager: match/return an existing TCP session, else an MRP session.
+- OperationalSessionSetup: establish over TCP when supportsTcpServer, else
+  leave the default MRP/UDP transport.
+---
+ src/app/OperationalSessionSetup.cpp |  9 +++++++++
+ src/transport/SessionManager.cpp    | 20 +++++++++++++++++++-
+ src/transport/SessionManager.h      |  5 ++++-
+ 3 files changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/src/app/OperationalSessionSetup.cpp b/src/app/OperationalSessionSetup.cpp
+index 5135e158..718a1f3a 100644
+--- a/src/app/OperationalSessionSetup.cpp
++++ b/src/app/OperationalSessionSetup.cpp
+@@ -329,6 +329,15 @@ CHIP_ERROR OperationalSessionSetup::EstablishConnection(const ResolveResult & re
+             return CHIP_ERROR_INTERNAL;
+         }
+     }
++    else if (mTransportPayloadCapability == TransportPayloadCapability::kLargePayloadWithMRPFallback)
++    {
++        // Prefer TCP for potentially large payloads, but tolerate peers without TCP support by
++        // silently falling back to the default MRP/UDP transport rather than failing the connect.
++        if (result.supportsTcpServer)
++        {
++            mDeviceAddress.SetTransportType(chip::Transport::Type::kTcp);
++        }
++    }
+ #endif
+ 
+     mCASEClient = mClientPool->Allocate();
+diff --git a/src/transport/SessionManager.cpp b/src/transport/SessionManager.cpp
+index ecd67f8a..bfc3da37 100644
+--- a/src/transport/SessionManager.cpp
++++ b/src/transport/SessionManager.cpp
+@@ -1251,7 +1251,8 @@ Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId pe
+             (!type.HasValue() || type.Value() == session->GetSecureSessionType()))
+         {
+             if (transportPayloadCapability == TransportPayloadCapability::kMRPOrTCPCompatiblePayload ||
+-                transportPayloadCapability == TransportPayloadCapability::kLargePayload)
++                transportPayloadCapability == TransportPayloadCapability::kLargePayload ||
++                transportPayloadCapability == TransportPayloadCapability::kLargePayloadWithMRPFallback)
+             {
+ #if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                 // Set up a TCP transport based session as standby
+@@ -1294,6 +1295,23 @@ Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId pe
+ 
+         return Optional<SessionHandle>::Missing();
+     }
++
++    if (transportPayloadCapability == TransportPayloadCapability::kLargePayloadWithMRPFallback)
++    {
++        // Prefer a TCP session for potentially large payloads, but fall back to an MRP session when
++        // TCP is unavailable (e.g. the peer does not support a TCP server).
++        if (tcpSession != nullptr)
++        {
++            return MakeOptional<SessionHandle>(*tcpSession);
++        }
++
++        if (mrpSession != nullptr)
++        {
++            return MakeOptional<SessionHandle>(*mrpSession);
++        }
++
++        return Optional<SessionHandle>::Missing();
++    }
+ #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+ 
+     return mrpSession != nullptr ? MakeOptional<SessionHandle>(*mrpSession) : Optional<SessionHandle>::Missing();
+diff --git a/src/transport/SessionManager.h b/src/transport/SessionManager.h
+index 84fbc183..3462cf1a 100644
+--- a/src/transport/SessionManager.h
++++ b/src/transport/SessionManager.h
+@@ -71,10 +71,13 @@ enum class TransportPayloadCapability : uint8_t
+     kLargePayload,             // Transport needs to handle payloads larger than the single IPv6
+                                // packet, as supported by MRP. The transport of choice, in this
+                                // case, is TCP.
+-    kMRPOrTCPCompatiblePayload // This option provides the ability to use MRP
++    kMRPOrTCPCompatiblePayload, // This option provides the ability to use MRP
+                                // as the preferred transport, but use a large
+                                // payload transport if that is already
+                                // available.
++    kLargePayloadWithMRPFallback // Prefer a large-payload (TCP) transport, establishing one when the
++                                 // peer advertises TCP server support, but fall back to MRP/UDP when
++                                 // it does not. Unlike kLargePayload this never fails on non-TCP peers.
+ };
+ /**
+  * @brief
+-- 
+2.43.0
+

--- a/third_party/matter/barton-library/patches/0003-transport-add-kLargePayloadWithMRPFallback-capabilit.patch
+++ b/third_party/matter/barton-library/patches/0003-transport-add-kLargePayloadWithMRPFallback-capabilit.patch
@@ -13,11 +13,12 @@ SDP) without breaking connections to UDP-only devices.
 - OperationalSessionSetup: establish over TCP when supportsTcpServer, else
   leave the default MRP/UDP transport.
 ---
- src/app/OperationalSessionSetup.cpp   |  9 +++++++++
- src/controller/CHIPDeviceController.h |  4 ++--
- src/transport/SessionManager.cpp      | 20 +++++++++++++++++++-
- src/transport/SessionManager.h        |  5 ++++-
- 4 files changed, 34 insertions(+), 4 deletions(-)
+ src/app/OperationalSessionSetup.cpp          |  9 +++++++++
+ src/controller/CHIPDeviceController.h        |  4 ++--
+ src/protocols/secure_channel/CASESession.cpp | 18 ++++++++++++++++++
+ src/transport/SessionManager.cpp             | 20 +++++++++++++++++++-
+ src/transport/SessionManager.h               |  5 ++++-
+ 5 files changed, 52 insertions(+), 4 deletions(-)
 
 diff --git a/src/app/OperationalSessionSetup.cpp b/src/app/OperationalSessionSetup.cpp
 index 5135e158..718a1f3a 100644
@@ -61,6 +62,35 @@ index bd530b87..91bf7c34 100644
      {
          VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
          mSystemState->CASESessionMgr()->FindOrEstablishSession(ScopedNodeId(peerNodeId, GetFabricIndex()), onConnection,
+diff --git a/src/protocols/secure_channel/CASESession.cpp b/src/protocols/secure_channel/CASESession.cpp
+index ad6ce283..aab315f0 100644
+--- a/src/protocols/secure_channel/CASESession.cpp
++++ b/src/protocols/secure_channel/CASESession.cpp
+@@ -540,6 +540,24 @@ CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, Fabric
+     {
+ #if INET_CONFIG_ENABLE_TCP_ENDPOINT
+         err = sessionManager.TCPConnect(peerAddress, nullptr, mPeerConnState);
++        if (err == CHIP_ERROR_NO_MEMORY)
++        {
++            // The active TCP connection pool is exhausted. Rather than failing the connection,
++            // gracefully fall back to establishing the CASE session over UDP/MRP. TCPConnect
++            // rejects before allocating any connection state in this case, so mPeerConnState is
++            // left untouched. Point both the unauthenticated session (which carries the Sigma
++            // exchange) and the secure session at the UDP transport so subsequent messages route
++            // over MRP instead of TCP.
++            ChipLogProgress(SecureChannel,
++                            "TCP connection pool exhausted; falling back to UDP for CASE session to "
++                            "0x" ChipLogFormatX64,
++                            ChipLogValueX64(mPeerNodeId));
++            peerAddress.SetTransportType(Transport::Type::kUdp);
++            mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetPeerAddress(peerAddress);
++            mSecureSessionHolder->AsSecureSession()->SetPeerAddress(peerAddress);
++            MATTER_LOG_METRIC_BEGIN(kMetricDeviceCASESessionSigma1);
++            err = SendSigma1();
++        }
+         SuccessOrExit(err);
+ #else
+         err = CHIP_ERROR_NOT_IMPLEMENTED;
 diff --git a/src/transport/SessionManager.cpp b/src/transport/SessionManager.cpp
 index ecd67f8a..bfc3da37 100644
 --- a/src/transport/SessionManager.cpp


### PR DESCRIPTION
Add a `kLargePayloadWithMRPFallback` transport capability that prefers a TCP session
for large payloads (e.g. WebRTC SDP) and transparently falls back to MRP/UDP for peers
without TCP support. Use it as the default for all controller connections.

- Patch the Matter library: add the capability and its SessionManager/
  OperationalSessionSetup handling, default GetConnectedDevice to it, and fall back to
  UDP (with a log) when the active TCP connection pool is full.
- Allow large-payload CommandSender buffers when the session supports them.
- Initiate GetConnectedDevice synchronously on the Matter thread in ConnectAndExecute.
- Log the GetConnectedDevice error in DeviceDataCache.
- Raise CHIP_CONFIG_MAX_ACTIVE_TCP_CONNECTIONS from 4 to 50.