### PR TITLE
feat(sbmd): add volatile resource mode

### DIFF
--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -530,11 +530,19 @@ std::optional<uint8_t> SpecBasedMatterDeviceDriver::ConvertModesToBitmask(const 
         {
             bitmask |= RESOURCE_MODE_EXECUTABLE;
         }
-        else if (mode == "dynamic" || mode == "emitEvents")
+        else if (mode == "dynamic")
         {
-            // Both are enabled by default (see the initial bitmask). Accept them as explicit
-            // no-ops so specs that list these default-on modes (valid per the schema and typings)
-            // register successfully instead of failing with "Unsupported resource mode".
+            // Enabled by default in the initial bitmask. Setting the bits explicitly (rather than
+            // treating this as a no-op) lets a spec re-enable dynamic behavior by listing "dynamic"
+            // after "static", since modes are applied in order.
+            bitmask |= RESOURCE_MODE_DYNAMIC | RESOURCE_MODE_DYNAMIC_CAPABLE;
+        }
+        else if (mode == "emitEvents")
+        {
+            // Enabled by default in the initial bitmask. Setting the bit explicitly lets a spec
+            // re-enable events by listing "emitEvents" after "noEvents", since modes are applied in
+            // order.
+            bitmask |= RESOURCE_MODE_EMIT_EVENTS;
         }
         else if (mode == "static")
         {
@@ -655,7 +663,11 @@ bool SpecBasedMatterDeviceDriver::DoRegisterDriverResources(icDevice *device)
             // Resources with explicit read handlers use CACHING_POLICY_NEVER so the driver is called.
             // The 'volatile' mode also forces CACHING_POLICY_NEVER so that, for a resource that emits
             // events, updateResource delivers an event on every call (no value-change suppression) even
-            // when the value is unchanged. Event-only signaling resources rely on this.
+            // when the value is unchanged. CACHING_POLICY_NEVER also means updateResource does not
+            // persist the value (or dateOfLastSyncMillis) to the device DB, and readable resources are
+            // served from the driver rather than the DB cache. 'volatile' is therefore intended for
+            // event-only signaling resources and should not be applied to subscription-backed state
+            // resources whose reads rely on the DB-cached value.
             bool isVolatile =
                 std::find(resource.modes.begin(), resource.modes.end(), "volatile") != resource.modes.end();
             ResourceCachingPolicy cachingPolicy =

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -530,6 +530,12 @@ std::optional<uint8_t> SpecBasedMatterDeviceDriver::ConvertModesToBitmask(const 
         {
             bitmask |= RESOURCE_MODE_EXECUTABLE;
         }
+        else if (mode == "dynamic" || mode == "emitEvents")
+        {
+            // Both are enabled by default (see the initial bitmask). Accept them as explicit
+            // no-ops so specs that list these default-on modes (valid per the schema and typings)
+            // register successfully instead of failing with "Unsupported resource mode".
+        }
         else if (mode == "static")
         {
             bitmask &= ~(RESOURCE_MODE_DYNAMIC | RESOURCE_MODE_DYNAMIC_CAPABLE);

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -530,19 +530,13 @@ std::optional<uint8_t> SpecBasedMatterDeviceDriver::ConvertModesToBitmask(const 
         {
             bitmask |= RESOURCE_MODE_EXECUTABLE;
         }
-        else if (mode == "dynamic")
+        else if (mode == "dynamic" || mode == "emitEvents")
         {
-            // Enabled by default in the initial bitmask. Setting the bits explicitly (rather than
-            // treating this as a no-op) lets a spec re-enable dynamic behavior by listing "dynamic"
-            // after "static", since modes are applied in order.
-            bitmask |= RESOURCE_MODE_DYNAMIC | RESOURCE_MODE_DYNAMIC_CAPABLE;
-        }
-        else if (mode == "emitEvents")
-        {
-            // Enabled by default in the initial bitmask. Setting the bit explicitly lets a spec
-            // re-enable events by listing "emitEvents" after "noEvents", since modes are applied in
-            // order.
-            bitmask |= RESOURCE_MODE_EMIT_EVENTS;
+            // Both are enabled by default (see the initial bitmask). Accept them as explicit
+            // no-ops so specs that list these default-on modes register successfully. Contradictory
+            // combinations with their opt-out counterparts ("static"/"noEvents") are rejected at
+            // spec-validation time by the schema's modes constraint, so no runtime resolution is
+            // needed here.
         }
         else if (mode == "static")
         {

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -647,8 +647,9 @@ bool SpecBasedMatterDeviceDriver::DoRegisterDriverResources(icDevice *device)
             // Resources without explicit read handlers are updated via attribute subscriptions,
             // so use CACHING_POLICY_ALWAYS to return the DB-cached value on read.
             // Resources with explicit read handlers use CACHING_POLICY_NEVER so the driver is called.
-            // The 'volatile' mode also forces CACHING_POLICY_NEVER so updateResource emits an event on
-            // every call (no value-change suppression), which event-only signaling resources rely on.
+            // The 'volatile' mode also forces CACHING_POLICY_NEVER so that, for a resource that emits
+            // events, updateResource delivers an event on every call (no value-change suppression) even
+            // when the value is unchanged. Event-only signaling resources rely on this.
             bool isVolatile =
                 std::find(resource.modes.begin(), resource.modes.end(), "volatile") != resource.modes.end();
             ResourceCachingPolicy cachingPolicy =

--- a/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
+++ b/core/deviceDrivers/matter/sbmd/SpecBasedMatterDeviceDriver.cpp
@@ -36,6 +36,7 @@
 #include "matter/sbmd/mquickjs/SbmdHandlerInvoker.h"
 #endif
 
+#include <algorithm>
 #include <app/ConcreteAttributePath.h>
 #include <cinttypes>
 #include <lib/core/TLVReader.h>
@@ -545,6 +546,11 @@ std::optional<uint8_t> SpecBasedMatterDeviceDriver::ConvertModesToBitmask(const 
         {
             bitmask |= RESOURCE_MODE_SENSITIVE;
         }
+        else if (mode == "volatile")
+        {
+            // Caching policy (CACHING_POLICY_NEVER) is applied separately in
+            // DoRegisterDriverResources; this mode contributes no access bit.
+        }
         else
         {
             icError("Unsupported resource mode: %s", mode.c_str());
@@ -641,8 +647,12 @@ bool SpecBasedMatterDeviceDriver::DoRegisterDriverResources(icDevice *device)
             // Resources without explicit read handlers are updated via attribute subscriptions,
             // so use CACHING_POLICY_ALWAYS to return the DB-cached value on read.
             // Resources with explicit read handlers use CACHING_POLICY_NEVER so the driver is called.
+            // The 'volatile' mode also forces CACHING_POLICY_NEVER so updateResource emits an event on
+            // every call (no value-change suppression), which event-only signaling resources rely on.
+            bool isVolatile =
+                std::find(resource.modes.begin(), resource.modes.end(), "volatile") != resource.modes.end();
             ResourceCachingPolicy cachingPolicy =
-                resource.read.has_value() ? CACHING_POLICY_NEVER : CACHING_POLICY_ALWAYS;
+                (resource.read.has_value() || isVolatile) ? CACHING_POLICY_NEVER : CACHING_POLICY_ALWAYS;
 
             // Seed initial value if there's a seed handler
             const char *initialValue = nullptr;

--- a/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
+++ b/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
@@ -255,7 +255,7 @@
             "type": "string",
             "enum": ["read", "write", "dynamic", "static", "emitEvents", "noEvents", "lazySaveNext", "sensitive", "volatile"]
           },
-          "description": "Access modes controlling resource behavior. 'volatile' disables value caching (CACHING_POLICY_NEVER) so updateResource emits an event on every call, even when the value is unchanged."
+          "description": "Access modes controlling resource behavior. 'volatile' disables value caching (CACHING_POLICY_NEVER) so that, for a resource that emits events, updateResource delivers an event on every call even when the value is unchanged."
         },
         "prerequisites": {
           "type": "array",

--- a/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
+++ b/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
@@ -255,7 +255,13 @@
             "type": "string",
             "enum": ["read", "write", "dynamic", "static", "emitEvents", "noEvents", "lazySaveNext", "sensitive", "volatile"]
           },
-          "description": "Access modes controlling resource behavior. 'volatile' disables value caching (CACHING_POLICY_NEVER) so that, for a resource that emits events, updateResource delivers an event on every call even when the value is unchanged. CACHING_POLICY_NEVER also stops persisting the last value/dateOfLastSyncMillis to the device DB, so 'volatile' is intended for event-only signaling resources, not subscription-backed state resources whose reads rely on the DB-cached value."
+          "not": {
+            "anyOf": [
+              { "allOf": [{ "contains": { "const": "static" } }, { "contains": { "const": "dynamic" } }] },
+              { "allOf": [{ "contains": { "const": "noEvents" } }, { "contains": { "const": "emitEvents" } }] }
+            ]
+          },
+          "description": "Access modes controlling resource behavior. 'static'/'dynamic' and 'noEvents'/'emitEvents' are mutually exclusive (each pair's members default on/off, so listing both is contradictory). 'volatile' disables value caching (CACHING_POLICY_NEVER) so that, for a resource that emits events, updateResource delivers an event on every call even when the value is unchanged. CACHING_POLICY_NEVER also stops persisting the last value/dateOfLastSyncMillis to the device DB, so 'volatile' is intended for event-only signaling resources, not subscription-backed state resources whose reads rely on the DB-cached value."
         },
         "prerequisites": {
           "type": "array",

--- a/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
+++ b/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
@@ -253,9 +253,9 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["read", "write", "dynamic", "static", "emitEvents", "noEvents", "lazySaveNext", "sensitive"]
+            "enum": ["read", "write", "dynamic", "static", "emitEvents", "noEvents", "lazySaveNext", "sensitive", "volatile"]
           },
-          "description": "Access modes controlling resource behavior."
+          "description": "Access modes controlling resource behavior. 'volatile' disables value caching (CACHING_POLICY_NEVER) so updateResource emits an event on every call, even when the value is unchanged."
         },
         "prerequisites": {
           "type": "array",

--- a/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
+++ b/core/deviceDrivers/matter/sbmd/schema/sbmd-spec-schema-v4.0.json
@@ -255,7 +255,7 @@
             "type": "string",
             "enum": ["read", "write", "dynamic", "static", "emitEvents", "noEvents", "lazySaveNext", "sensitive", "volatile"]
           },
-          "description": "Access modes controlling resource behavior. 'volatile' disables value caching (CACHING_POLICY_NEVER) so that, for a resource that emits events, updateResource delivers an event on every call even when the value is unchanged."
+          "description": "Access modes controlling resource behavior. 'volatile' disables value caching (CACHING_POLICY_NEVER) so that, for a resource that emits events, updateResource delivers an event on every call even when the value is unchanged. CACHING_POLICY_NEVER also stops persisting the last value/dateOfLastSyncMillis to the device DB, so 'volatile' is intended for event-only signaling resources, not subscription-backed state resources whose reads rely on the DB-cached value."
         },
         "prerequisites": {
           "type": "array",

--- a/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts
+++ b/core/deviceDrivers/matter/sbmd/scriptCommon/sbmd-script.d.ts
@@ -151,9 +151,10 @@ interface SbmdResource {
 
     /**
      * Access modes: "read", "write", "dynamic" (default on), "static" (opts out of dynamic),
-     * "emitEvents" (default on), "noEvents", "lazySaveNext", "sensitive".
+     * "emitEvents" (default on), "noEvents", "lazySaveNext", "sensitive", "volatile" (disables
+     * value caching).
      */
-    modes?: Array<"read" | "write" | "dynamic" | "static" | "emitEvents" | "noEvents" | "lazySaveNext" | "sensitive">;
+    modes?: Array<"read" | "write" | "dynamic" | "static" | "emitEvents" | "noEvents" | "lazySaveNext" | "sensitive" | "volatile">;
 
     /** Alias names or cluster IDs that must be present before creating this resource. */
     prerequisites?: Array<string | number>;


### PR DESCRIPTION
Add a 'volatile' resource mode that disables value caching (CACHING_POLICY_NEVER) so updateResource emits an event on every call, even when the value is unchanged. This supports event-only signaling resources where identical values must each be delivered as distinct events (e.g. repeated 'failed' notifications across sessions), which the default cached behavior would suppress.

Wire it through the JSON schema, the script type definitions, and the SBMD driver's caching-policy selection.