### PR TITLE
chore: Add support for rtk

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,8 @@
     // NOTE: VSC will copy some files post-config; .ssh/known_hosts, .gitconfig, etc
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind"
+        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind",
+        "source=${localEnv:HOME}/.claude,target=/home/${localEnv:USER}/.claude,type=bind"
     ],
 
     // By setting this value to true, VSC will not run the entrypoint/CMD in the Dockerfile

--- a/docker/Dockerfile.devcontainer
+++ b/docker/Dockerfile.devcontainer
@@ -62,5 +62,5 @@ RUN npm install -g prettier@3.3.3 lint-staged@15.2.10
 # User local installations
 USER $BUILDER_USER
 
-RUN curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh && \
-    echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+RUN curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+ENV PATH="/home/${BUILDER_USER}/.local/bin:${PATH}"

--- a/docker/Dockerfile.devcontainer
+++ b/docker/Dockerfile.devcontainer
@@ -58,3 +58,9 @@ RUN npm install -g @fission-ai/openspec@v1.4.1
 # Formatting tooling for the pre-commit hook: Prettier formats the JavaScript SBMD
 # drivers (see .prettierrc.yaml) and lint-staged runs it over staged files.
 RUN npm install -g prettier@3.3.3 lint-staged@15.2.10
+
+# User local installations
+USER $BUILDER_USER
+
+RUN curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh && \
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc


### PR DESCRIPTION
Add support in the devcontainer for rtk and mount the user's ~/.claude directory. To use rtk automatically in vs code copilot chat, enable "chat.useClaudeHooks" in your vsc settings and reload (only works on new sessions). This change assumes the user has rtk installed and initialized globally. It does not run rtk init in the project.