### PR TITLE
fix(camera): add Barton session metadata

### DIFF
--- a/core/deviceDrivers/matter/sbmd/specs/camera.sbmd.js
+++ b/core/deviceDrivers/matter/sbmd/specs/camera.sbmd.js
@@ -336,8 +336,7 @@ function parseSessions(sessionsJson) {
 }
 
 function findStreamingSessionId(sessions) {
-    if (sessions === null || sessions === undefined)
-    {
+    if (sessions === null || sessions === undefined) {
         return null;
     }
 
@@ -356,22 +355,17 @@ function findStreamingSessionId(sessions) {
 // webRTCSessionID so the resource update event can be attributed to the exact
 // session, which matters when multiple clients are active and streaming-state
 // inference would be ambiguous.
-function findSessionIdByWebRTCSessionID(sessions, webRTCSessionID)
-{
-    if (webRTCSessionID === undefined || webRTCSessionID === null)
-    {
+function findSessionIdByWebRTCSessionID(sessions, webRTCSessionID) {
+    if (webRTCSessionID === undefined || webRTCSessionID === null) {
         return null;
     }
 
-    if (sessions === null || sessions === undefined)
-    {
+    if (sessions === null || sessions === undefined) {
         return null;
     }
 
-    for (var id in sessions)
-    {
-        if (sessions[id].webRTCSessionID === webRTCSessionID)
-        {
+    for (var id in sessions) {
+        if (sessions[id].webRTCSessionID === webRTCSessionID) {
             return id;
         }
     }
@@ -962,7 +956,7 @@ function handleIncomingOffer(args) {
     // Store the Matter webRTCSessionID for correlation
     var sessionsJson = args.supplements.transientData[TD_SESSIONS];
     var sessions = parseSessions(sessionsJson);
-    var sessionId = findStreamingSessionId(sessions);
+    var sessionId = findSessionIdByWebRTCSessionID(sessions, webRTCSessionID);
     var metadata = {sessionId: sessionId || 'unknown'};
 
     if (sessions === null) {
@@ -1003,7 +997,7 @@ function handleIncomingAnswer(args) {
 
     var sessionsJson = args.supplements.transientData[TD_SESSIONS];
     var sessions = parseSessions(sessionsJson);
-    var sessionId = findStreamingSessionId(sessions);
+    var sessionId = findSessionIdByWebRTCSessionID(sessions, webRTCSessionID);
     var metadata = {sessionId: sessionId || 'unknown'};
 
     // Store the camera-allocated webRTCSessionID for use by subsequent commands
@@ -1055,7 +1049,12 @@ function handleIncomingIceCandidates(args) {
     }
 
     return Sbmd.result()
-        .dataModel.updateResource(EP_WEBRTC, 'remoteIceCandidates', JSON.stringify(candidates), metadata)
+        .dataModel.updateResource(
+            EP_WEBRTC,
+            'remoteIceCandidates',
+            JSON.stringify(candidates),
+            metadata
+        )
         .success();
 }
 

--- a/core/deviceDrivers/matter/sbmd/specs/camera.sbmd.js
+++ b/core/deviceDrivers/matter/sbmd/specs/camera.sbmd.js
@@ -336,9 +336,42 @@ function parseSessions(sessionsJson) {
 }
 
 function findStreamingSessionId(sessions) {
+    if (sessions === null || sessions === undefined)
+    {
+        return null;
+    }
+
     // Return the id of the (single) session in the 'streaming' state, or null if there is none.
     for (var id in sessions) {
         if (sessions[id].state === 'streaming') {
+            return id;
+        }
+    }
+
+    return null;
+}
+
+// Return the session id whose stored webRTCSessionID matches an incoming
+// WebRTCTransportRequestor command. Use this when the command already carries a
+// webRTCSessionID so the resource update event can be attributed to the exact
+// session, which matters when multiple clients are active and streaming-state
+// inference would be ambiguous.
+function findSessionIdByWebRTCSessionID(sessions, webRTCSessionID)
+{
+    if (webRTCSessionID === undefined || webRTCSessionID === null)
+    {
+        return null;
+    }
+
+    if (sessions === null || sessions === undefined)
+    {
+        return null;
+    }
+
+    for (var id in sessions)
+    {
+        if (sessions[id].webRTCSessionID === webRTCSessionID)
+        {
             return id;
         }
     }
@@ -929,25 +962,25 @@ function handleIncomingOffer(args) {
     // Store the Matter webRTCSessionID for correlation
     var sessionsJson = args.supplements.transientData[TD_SESSIONS];
     var sessions = parseSessions(sessionsJson);
+    var sessionId = findStreamingSessionId(sessions);
+    var metadata = {sessionId: sessionId || 'unknown'};
 
     if (sessions === null) {
         // Corrupt session data: reset it, but still surface the remote SDP to the client.
         return Sbmd.result()
             .storage.setTransientData(TD_SESSIONS, '', 0)
-            .dataModel.updateResource(EP_WEBRTC, 'remoteSdp', sdp.toString())
+            .dataModel.updateResource(EP_WEBRTC, 'remoteSdp', sdp.toString(), metadata)
             .success();
     }
 
     // Find the active streaming session and associate the Matter session ID.
-    var sessionId = findStreamingSessionId(sessions);
-
     if (sessionId) {
         sessions[sessionId].webRTCSessionID = webRTCSessionID;
     }
 
     return Sbmd.result()
         .storage.setTransientData(TD_SESSIONS, JSON.stringify(sessions), ONE_HOUR_SECS)
-        .dataModel.updateResource(EP_WEBRTC, 'remoteSdp', sdp.toString())
+        .dataModel.updateResource(EP_WEBRTC, 'remoteSdp', sdp.toString(), metadata)
         .success();
 }
 
@@ -968,11 +1001,13 @@ function handleIncomingAnswer(args) {
         return Sbmd.result().error('Answer command missing SDP');
     }
 
-    // Store the camera-allocated webRTCSessionID for use by subsequent commands
-    // (ProvideICECandidates, EndSession)
     var sessionsJson = args.supplements.transientData[TD_SESSIONS];
     var sessions = parseSessions(sessionsJson);
+    var sessionId = findStreamingSessionId(sessions);
+    var metadata = {sessionId: sessionId || 'unknown'};
 
+    // Store the camera-allocated webRTCSessionID for use by subsequent commands
+    // (ProvideICECandidates, EndSession)
     if (sessions && webRTCSessionID !== undefined && webRTCSessionID !== null) {
         var answerSessionId = findStreamingSessionId(sessions);
 
@@ -983,7 +1018,7 @@ function handleIncomingAnswer(args) {
 
     return Sbmd.result()
         .storage.setTransientData(TD_SESSIONS, JSON.stringify(sessions || {}), ONE_HOUR_SECS)
-        .dataModel.updateResource(EP_WEBRTC, 'remoteSdp', sdp.toString())
+        .dataModel.updateResource(EP_WEBRTC, 'remoteSdp', sdp.toString(), metadata)
         .success();
 }
 
@@ -997,11 +1032,18 @@ function handleIncomingIceCandidates(args) {
     var decoded = Sbmd.Tlv.decode(tlvBase64);
 
     // ICECandidates fields: webRTCSessionID (tag 0), ICECandidates (tag 1, array of structs)
+    var webRTCSessionID = decoded[0];
     var candidateStructs = decoded[1];
 
     if (!candidateStructs || !Array.isArray(candidateStructs)) {
         return Sbmd.result().error('ICECandidates command missing candidates array');
     }
+
+    var sessionsJson = args.supplements.transientData[TD_SESSIONS];
+    var sessions = parseSessions(sessionsJson);
+    var sessionId = findSessionIdByWebRTCSessionID(sessions, webRTCSessionID);
+
+    var metadata = {sessionId: sessionId || 'unknown'};
 
     // Extract candidate strings from ICECandidateStruct array
     // Each struct has: candidate (tag 0), SDPMid (tag 1), SDPMLineIndex (tag 2)
@@ -1013,18 +1055,21 @@ function handleIncomingIceCandidates(args) {
     }
 
     return Sbmd.result()
-        .dataModel.updateResource(EP_WEBRTC, 'remoteIceCandidates', JSON.stringify(candidates))
+        .dataModel.updateResource(EP_WEBRTC, 'remoteIceCandidates', JSON.stringify(candidates), metadata)
         .success();
 }
 
 function handleIncomingEndSession(args) {
     var tlvBase64 = args.command.tlvBase64;
     var reason = 12; // UnknownReason default
+    var webRTCSessionID = null;
 
     if (tlvBase64) {
         var decoded = Sbmd.Tlv.decode(tlvBase64);
 
         // End fields: webRTCSessionID (tag 0), reason (tag 1)
+        webRTCSessionID = decoded[0];
+
         if (decoded[1] !== undefined) {
             reason = decoded[1];
         }
@@ -1046,7 +1091,10 @@ function handleIncomingEndSession(args) {
             .success();
     }
 
-    var sessionId = findStreamingSessionId(sessions);
+    // Use the camera-provided webRTCSessionID so the ended event is attributed to the exact
+    // session that the camera is ending. If we cannot resolve that id, still publish the ended
+    // event with sessionId='unknown' rather than guessing from the current streaming state.
+    var sessionId = findSessionIdByWebRTCSessionID(sessions, webRTCSessionID);
 
     if (sessionId) {
         delete sessions[sessionId];

--- a/core/test/src/SbmdCameraWebrtcTest.cpp
+++ b/core/test/src/SbmdCameraWebrtcTest.cpp
@@ -761,7 +761,7 @@ namespace
 
     TEST_F(SbmdCameraWebrtcTest, HandleIncomingOfferUpdatesRemoteSdp)
     {
-        std::string sessions = SessionsJson("1", "streaming");
+        std::string sessions = SessionsJson("1", "streaming", 42);
         auto tlv = EncodeTlv("{webRTCSessionID:{tag:0,type:'uint16'}, sdp:{tag:1,type:'string'}}",
                              "{webRTCSessionID: 42, sdp: 'remote-offer-sdp'}");
 
@@ -776,7 +776,7 @@ namespace
 
     TEST_F(SbmdCameraWebrtcTest, HandleIncomingAnswerUpdatesRemoteSdp)
     {
-        std::string sessions = SessionsJson("1", "streaming");
+        std::string sessions = SessionsJson("1", "streaming", 99);
         auto tlv = EncodeTlv("{webRTCSessionID:{tag:0,type:'uint16'}, sdp:{tag:1,type:'string'}}",
                              "{webRTCSessionID: 99, sdp: 'remote-answer-sdp'}");
 
@@ -852,7 +852,7 @@ namespace
         EXPECT_TRUE(ur->metadata->find("reason") != std::string::npos);
     }
 
-    TEST_F(SbmdCameraWebrtcTest, HandleIncomingEndWithUnknownWebRTCSessionIDReturnsError)
+    TEST_F(SbmdCameraWebrtcTest, HandleIncomingEndWithUnknownWebRTCSessionIDExpectSuccess)
     {
         std::string sessions = SessionsJson("1", "streaming", 42);
         auto tlv = EncodeTlv("{webRTCSessionID:{tag:0,type:'uint16'}, reason:{tag:1,type:'enum8'}}",

--- a/core/test/src/SbmdCameraWebrtcTest.cpp
+++ b/core/test/src/SbmdCameraWebrtcTest.cpp
@@ -769,7 +769,9 @@ namespace
             InvokeCommandHandler("handleIncomingOffer", CL_WEBRTC_TRANSPORT_REQUESTOR, CMD_OFFER, tlv, sessions);
 
         ExpectSuccess(result);
-        ExpectUpdateResource(*result, "remoteSdp", "remote-offer-sdp");
+        const auto *ur = ExpectUpdateResource(*result, "remoteSdp", "remote-offer-sdp");
+        ASSERT_TRUE(ur->metadata.has_value());
+        EXPECT_TRUE(ur->metadata->find("\"sessionId\":\"1\"") != std::string::npos);
     }
 
     TEST_F(SbmdCameraWebrtcTest, HandleIncomingAnswerUpdatesRemoteSdp)
@@ -782,7 +784,9 @@ namespace
             InvokeCommandHandler("handleIncomingAnswer", CL_WEBRTC_TRANSPORT_REQUESTOR, CMD_ANSWER, tlv, sessions);
 
         ExpectSuccess(result);
-        ExpectUpdateResource(*result, "remoteSdp", "remote-answer-sdp");
+        const auto *ur = ExpectUpdateResource(*result, "remoteSdp", "remote-answer-sdp");
+        ASSERT_TRUE(ur->metadata.has_value());
+        EXPECT_TRUE(ur->metadata->find("\"sessionId\":\"1\"") != std::string::npos);
     }
 
     TEST_F(SbmdCameraWebrtcTest, HandleIncomingAnswerStoresWebRTCSessionID)
@@ -812,7 +816,24 @@ namespace
             "handleIncomingIceCandidates", CL_WEBRTC_TRANSPORT_REQUESTOR, CMD_ICE_CANDIDATES, tlv, sessions);
 
         ExpectSuccess(result);
-        ExpectUpdateResource(*result, "remoteIceCandidates");
+        const auto *ur = ExpectUpdateResource(*result, "remoteIceCandidates");
+        ASSERT_TRUE(ur->metadata.has_value());
+        EXPECT_TRUE(ur->metadata->find("\"sessionId\":\"1\"") != std::string::npos);
+    }
+
+    TEST_F(SbmdCameraWebrtcTest, HandleIncomingIceCandidatesWithoutWebRTCSessionIDEmitsUnknownMetadata)
+    {
+        std::string sessions = SessionsJson("1", "streaming", 42);
+        auto tlv = EncodeTlv("{webRTCSessionID:{tag:0,type:'uint16'}, ICECandidates:{tag:1,type:'array'}}",
+                             "{webRTCSessionID: null, ICECandidates: [{0:'candidate:1 udp host', 1:null, 2:null}]}");
+
+        auto result = InvokeCommandHandler(
+            "handleIncomingIceCandidates", CL_WEBRTC_TRANSPORT_REQUESTOR, CMD_ICE_CANDIDATES, tlv, sessions);
+
+        ExpectSuccess(result);
+        const auto *ur = ExpectUpdateResource(*result, "remoteIceCandidates");
+        ASSERT_TRUE(ur->metadata.has_value());
+        EXPECT_TRUE(ur->metadata->find("\"sessionId\":\"unknown\"") != std::string::npos);
     }
 
     TEST_F(SbmdCameraWebrtcTest, HandleIncomingEndEmitsWebrtcErrorEnded)
@@ -827,8 +848,23 @@ namespace
         ExpectSuccess(result);
         const auto *ur = ExpectUpdateResource(*result, "webrtcError", "ended");
         ASSERT_TRUE(ur->metadata.has_value());
-        EXPECT_TRUE(ur->metadata->find("sessionId") != std::string::npos);
+        EXPECT_TRUE(ur->metadata->find("\"sessionId\":\"1\"") != std::string::npos);
         EXPECT_TRUE(ur->metadata->find("reason") != std::string::npos);
+    }
+
+    TEST_F(SbmdCameraWebrtcTest, HandleIncomingEndWithUnknownWebRTCSessionIDReturnsError)
+    {
+        std::string sessions = SessionsJson("1", "streaming", 42);
+        auto tlv = EncodeTlv("{webRTCSessionID:{tag:0,type:'uint16'}, reason:{tag:1,type:'enum8'}}",
+                             "{webRTCSessionID: 99, reason: 2}");
+
+        auto result =
+            InvokeCommandHandler("handleIncomingEndSession", CL_WEBRTC_TRANSPORT_REQUESTOR, CMD_END, tlv, sessions);
+
+        ExpectSuccess(result);
+        const auto *ur = ExpectUpdateResource(*result, "webrtcError", "ended");
+        ASSERT_TRUE(ur->metadata.has_value());
+        EXPECT_TRUE(ur->metadata->find("\"sessionId\":\"unknown\"") != std::string::npos);
     }
 
     TEST_F(SbmdCameraWebrtcTest, ExecuteStreamReturnsProtocolAndEntryPoint)


### PR DESCRIPTION
- Attach sessionId metadata to remoteSdp and remoteIceCandidates so the client can correlate incoming WebRTC updates to the correct Barton session.

Previously, when incoming WebRTC updates arrived, we inferred the session from the active streaming state. That worked when only one client was active, but it became ambiguous once multiple clients could be streaming at the same time.

- To resolve that ambiguity, use the camera's webRTCSessionID to infer the Barton session directly when it is available.