### PR TITLE
chore: Install project-specific rtk hooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
         "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind",
-        "source=${localEnv:HOME}/.claude,target=/home/${localEnv:USER}/.claude,type=bind"
+        "source=${localEnv:HOME}/.local/share/rtk/,target=/home/${localEnv:USER}/.local/share/rtk/,type=bind"
     ],
 
     // By setting this value to true, VSC will not run the entrypoint/CMD in the Dockerfile

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 
 {
     "name": "Barton Ubuntu Development Environment",
-    "initializeCommand": "docker/setupDockerEnv.sh",
+    "initializeCommand": ".devcontainer/setupDevcontainerEnv.sh",
     "dockerComposeFile": [
         "../docker/compose.yaml",
         "../docker/compose.devcontainer.yaml"

--- a/.devcontainer/setupDevcontainerEnv.sh
+++ b/.devcontainer/setupDevcontainerEnv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# ------------------------------ tabstop = 4 ----------------------------------
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2026 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# ------------------------------ tabstop = 4 ----------------------------------
+
+# Prepare host resources required only by the VS Code devcontainer.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# Create the RTK bind-mount source as the invoking host user before Docker starts.
+mkdir -p "$HOME/.local/share/rtk"
+
+"$SCRIPT_DIR/../docker/setupDockerEnv.sh"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,3 +14,31 @@
 These rules are **not fully enforceable by clang-format** -- `SeparateDefinitionBlocks: Always` in `.clang-format` handles blank lines between top-level definitions, but the within-function rules below must be applied manually.
 - Always place a blank line before `if`, `for`, `while`, `switch`, and `return` statements, unless the preceding line is an opening brace or another control flow statement's opening line.
 - Always place a blank line after a closing brace `}` unless it is followed by `else`, `catch`, or another closing brace.
+
+<!-- rtk-instructions v2 -->
+# RTK — Token-Optimized CLI
+
+**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
+
+## Rule
+
+Always prefix shell commands with `rtk`:
+
+```bash
+# Instead of:              Use:
+git status                 rtk git status
+git log -10                rtk git log -10
+cargo test                 rtk cargo test
+docker ps                  rtk docker ps
+kubectl get pods           rtk kubectl get pods
+```
+
+## Meta commands (use directly)
+
+```bash
+rtk gain              # Token savings dashboard
+rtk gain --history    # Per-command savings history
+rtk discover          # Find missed rtk opportunities
+rtk proxy <cmd>       # Run raw (no filtering) but track usage
+```
+<!-- /rtk-instructions -->

--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "rtk hook copilot",
+        "cwd": ".",
+        "timeout": 5
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "rtk hook copilot",
+        "powershell": "rtk hook copilot",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Moving from a global hook to a project one. For now, only copilot's hook is installed. Other tools (eg, opencode, gemini, claude) would need to be installed separately. This commit also forward's the host's history db to the devcontainer so commands and estimated savings from commands within the devcontainer can contribute to the host's global user tracking. If a user does not have rtk installed on the host, this will just create the empty directory ~/.local/share/rtk on the host.