### PR TITLE
fix(api)!: annotate execute_resource response as an out parameter

### DIFF
--- a/api/c/public/barton-core-client.h
+++ b/api/c/public/barton-core-client.h
@@ -466,7 +466,7 @@ gboolean b_core_client_remove_endpoint_by_id(BCoreClient *self, const gchar *dev
  * @self: the BCoreClient instance.
  * @uri: the URI of the resource to execute.
  * @payload: JSON payload to send to the resource to execute. (optional)
- * @response: the response from the executed resource.(optional)
+ * @response: (out) (optional) (nullable) (transfer full): the response from the executed resource.
  *
  * @brief Execute a resource based on the URI with the optional payload.
  *

--- a/testing/test/door_lock_test.py
+++ b/testing/test/door_lock_test.py
@@ -69,7 +69,7 @@ def test_lock_unlock_via_barton(default_environment, matter_door_lock):
     resource_updated_queue = resource_update_listener(client, "locked")
 
     # Unlock via Barton — execute the "unlock" function resource
-    client.execute_resource(resource_uri(lock, "unlock", endpoint_id=1), "", "")
+    client.execute_resource(resource_uri(lock, "unlock", endpoint_id=1), "")
     wait_for_resource_value(resource_updated_queue, "false")
 
     # Verify via side-band
@@ -77,7 +77,7 @@ def test_lock_unlock_via_barton(default_environment, matter_door_lock):
     assert state["lockState"] == "unlocked"
 
     # Lock via Barton — execute the "lock" function resource
-    client.execute_resource(resource_uri(lock, "lock", endpoint_id=1), "", "")
+    client.execute_resource(resource_uri(lock, "lock", endpoint_id=1), "")
     wait_for_resource_value(resource_updated_queue, "true", timeout=10)
 
     # Verify via side-band

--- a/testing/test/sbmd_deferred_metrics_test.py
+++ b/testing/test/sbmd_deferred_metrics_test.py
@@ -113,7 +113,7 @@ def test_deferred_duration_and_in_flight_metrics(
     # The virtual device starts with isOn=false.  Toggling produces an OnOff
     # attribute report that confirms end-to-end completion.
     resource_updated_queue = resource_update_listener(client, "isOn")
-    client.execute_resource(resource_uri(device, "toggle", endpoint_id=1), "", "")
+    client.execute_resource(resource_uri(device, "toggle", endpoint_id=1), "")
     wait_for_resource_value(resource_updated_queue, "true", timeout=10)
 
     telemetry = json.loads(client.get_telemetry())
@@ -169,7 +169,7 @@ def test_deferred_depth_zero_for_single_round_trip(
     client = default_environment.get_client()
 
     resource_updated_queue = resource_update_listener(client, "isOn")
-    client.execute_resource(resource_uri(device, "toggle", endpoint_id=1), "", "")
+    client.execute_resource(resource_uri(device, "toggle", endpoint_id=1), "")
     wait_for_resource_value(resource_updated_queue, "true", timeout=10)
 
     telemetry = json.loads(client.get_telemetry())


### PR DESCRIPTION
b_core_client_execute_resource's response argument had no GObject
Introspection direction annotation, so language bindings treated it as an
input. Handlers that write a response (e.g. the camera stream springboard)
could not have it retrieved from bindings, and writing the out value
overflowed the caller-supplied buffer. Annotate it
(out) (optional) (nullable) (transfer full) so bindings return it. Existing
Python callers are updated to the new form.

BREAKING CHANGE: b_core_client_execute_resource exposes response as an out
parameter. Language bindings drop the response argument and return it
instead (Python: "ok, response = client.execute_resource(uri, payload)").
This bumps the introspected API major version (BCore-N.0). C callers that
pass &response or NULL are unaffected.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>